### PR TITLE
KRACOEUS-7097: Sponsor name not updating in Prop Dev

### DIFF
--- a/coeus-code/src/main/resources/org/kuali/kra/datadictionary/krad/propdev/ProposalDetailsPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/kra/datadictionary/krad/propdev/ProposalDetailsPage.xml
@@ -152,7 +152,7 @@
 		</property>
 		<property name="control">
 			<bean parent="Uif-TextControl"
-				p:onBlurScript="Kc.PropDev.updateSponsorName(jQuery(this).val(), jQuery(this).parent().find('.informationalText'));" />
+				p:onBlurScript="Kc.PropDev.updateSponsorName(jQuery(this).val(), jQuery(this).parents('.uif-inputField:first').find('.informationalText'));" />
 		</property>
 	</bean>
 


### PR DESCRIPTION
KRAD changed their DOM structure so that we have to look at the parent of the parent to find the <p> tag to update.
