### PR TITLE
KRACOEUS-7220 : Include script.cleanup option in mvn dev profile.

### DIFF
--- a/coeus-webapp/pom.xml
+++ b/coeus-webapp/pom.xml
@@ -23,6 +23,7 @@
     <properties>
         <build.rice.kr.additionalSpringFiles />
         <build.rice.krad.dev.mode>false</build.rice.krad.dev.mode>
+        <build.rice.krad.script.cleanup>true</build.rice.krad.script.cleanup>
 
         <!-- jetty & tomcat properties -->
         <kc.context.path>/kc-${build.environment}</kc.context.path>
@@ -441,6 +442,7 @@
             <properties>
                 <build.rice.kr.additionalSpringFiles>classpath:org/kuali/rice/krad/devtools/datadictionary/ReloadingDataDictionarySpringBeans.xml</build.rice.kr.additionalSpringFiles>
                 <build.rice.krad.dev.mode>true</build.rice.krad.dev.mode>
+                <build.rice.krad.script.cleanup>false</build.rice.krad.script.cleanup>
             </properties>
             <dependencies>
                 <dependency>

--- a/coeus-webapp/src/main/resources/META-INF/kc-config-build.xml
+++ b/coeus-webapp/src/main/resources/META-INF/kc-config-build.xml
@@ -21,4 +21,5 @@ This config file only contains properties that are set by the maven build proces
 	<param name="version">${build.version}</param>
     <param name="rice.kr.additionalSpringFiles">${build.rice.kr.additionalSpringFiles}</param>
     <param name="rice.krad.dev.mode">${build.rice.krad.dev.mode}</param>
+    <param name="rice.krad.script.cleanup">${build.rice.krad.script.cleanup}</param>
 </config>


### PR DESCRIPTION
Leaves KRAD <input> tags containing JS behind after page load which makes debugging broken properties(eg. progressiverRender) much easier.
