### PR TITLE
KRACOEUS-7001 : Fix outdated addViaLightBox action references

### DIFF
--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/location/ProposalOrganizationLocationsPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/location/ProposalOrganizationLocationsPage.xml
@@ -127,8 +127,8 @@
 	<bean id="PropDev-CongressionalDistricts-Section-parentBean" abstract="true"
 		parent="PropDev-Attachment-Collection" p:collectionObjectClass="org.kuali.coeus.propdev.impl.location.CongressionalDistrict"
 		p:propertyName="congressionalDistricts" p:layoutManager.summaryTitle="@{#lp.congressionalDistrict}">
-		<property name="addViaLightBoxAction">
-            <bean parent="Uif-AddViaLightBoxAction" p:actionLabel="Add Congressioanl District" p:iconClass="icon-plus"/>
+		<property name="addWithDialogAction">
+            <bean parent="Uif-AddWithDialogAction" p:actionLabel="Add Congressioanl District" p:iconClass="icon-plus"/>
         </property>	
 		<property name="lineActions">
             <list>
@@ -209,8 +209,8 @@
 	<bean id="PropDev-OtherOrganizationsPage-CongressionalDistricts-parentBean" abstract="true" parent="PropDev-Attachment-Collection" 
 		p:collectionObjectClass="org.kuali.coeus.propdev.impl.location.CongressionalDistrict" p:propertyName="congressionalDistricts"
 		p:layoutManager.summaryTitle="@{#lp.congressionalDistrict}" >
-		<property name="addViaLightBoxAction">
-            <bean parent="Uif-AddViaLightBoxAction" p:actionLabel="Add Congressioanl District" p:iconClass="icon-plus"/>
+		<property name="addWithDialogAction">
+            <bean parent="Uif-AddWithDialogAction" p:actionLabel="Add Congressioanl District" p:iconClass="icon-plus"/>
         </property>	
 		<property name="lineActions">
             <list>                


### PR DESCRIPTION
This is a critical change, as due to a change I didn't notice when I merged the previous 7001 PR, the app will not start without this.
