### PR TITLE
KRACOEUS-7379 : Custom HREF iframe view

### DIFF
--- a/coeus-code/src/main/java/org/kuali/kra/web/krad/CustomHrefIframeView.java
+++ b/coeus-code/src/main/java/org/kuali/kra/web/krad/CustomHrefIframeView.java
@@ -1,0 +1,16 @@
+package org.kuali.kra.web.krad;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.rice.krad.uif.view.IframeView;
+
+public class CustomHrefIframeView extends IframeView {
+
+    @Override
+    public void performInitialization(Object model) {
+        super.performInitialization(model);
+        if (model instanceof LandingPageForm
+        		&& StringUtils.isNotBlank(((LandingPageForm) model).getHref())) {
+        	setHref(((LandingPageForm) model).getHref());
+        }
+    }
+}

--- a/coeus-code/src/main/java/org/kuali/kra/web/krad/LandingPageForm.java
+++ b/coeus-code/src/main/java/org/kuali/kra/web/krad/LandingPageForm.java
@@ -15,13 +15,29 @@
  */
 package org.kuali.kra.web.krad;
 
+import org.kuali.rice.krad.web.bind.RequestAccessible;
 import org.kuali.rice.krad.web.form.UifFormBase;
 
 public class LandingPageForm extends UifFormBase {
 
     private static final long serialVersionUID = 304896781932966963L;
+    
+    @RequestAccessible
+    private String href;
 
     public LandingPageForm() {
         setViewId("Kc-LandingPage-DefaultView");
     }
+
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * Href is used for CustomLinkIframeView. Avoids needing to create custom views for each link
+	 * @param href
+	 */
+	public void setHref(String href) {
+		this.href = href;
+	}
 }

--- a/coeus-code/src/main/resources/org/kuali/kra/datadictionary/krad/common/KcApplicationHeader.xml
+++ b/coeus-code/src/main/resources/org/kuali/kra/datadictionary/krad/common/KcApplicationHeader.xml
@@ -107,7 +107,7 @@
 		p:actionUrl.controllerMapping="/landingPage" />
 
 	<bean id="Kc-Header-IframeView" parent="Kc-Header-IframeView-parentBean" />
-	<bean id="Kc-Header-IframeView-parentBean" abstract="true"
+	<bean id="Kc-Header-IframeView-parentBean" abstract="true" class="org.kuali.kra.web.krad.CustomHrefIframeView"
 		parent="Uif-IframeView" p:location.baseUrl="@{#ConfigProperties['application.url']}" />
 
 	<bean id="Kc-Header-ActionListView" parent="Kc-Header-ActionListView-parentBean" />
@@ -260,8 +260,11 @@
 					p:order="50" />
 				<bean parent="Uif-SimpleHeaderFour" p:headerText="Lists"
 					p:order="60" />
-				<bean parent="Uif-MenuAction" p:actionLabel="Pending Protocols"
-					p:order="70" />
+				<bean parent="Kc-Header-IframeMenuAction" p:actionUrl.viewId="Kc-Header-IframeView" p:actionLabel="Pending Protocols" p:order="70">
+					<property name="actionUrl.requestParameters">
+						<map><entry key="href" value="@{#ConfigProperties['application.url']}/kr/lookup.do?methodToCall=search&amp;businessObjectClassName=org.kuali.kra.irb.Protocol&amp;docFormKey=88888888&amp;returnLocation=@{#ConfigProperties['application.url']}/portal.do&amp;hideReturnLink=true&amp;lookupPendingProtocol=true"/></map>
+					</property>
+				</bean>
 				<bean parent="Uif-MenuAction" p:actionLabel="Protocols Pending PI Action"
 					p:order="80" />
 				<bean parent="Uif-MenuAction" p:actionLabel="Protocols Pending Committee Action"


### PR DESCRIPTION
This will allow devs to more easily copy and paste from the tag files the links we require into the KRAD header. This work will eliminate the need to create iframe view beans for each link. To create the actionUrl.requestParameters we can simply copy from the tag files, escape & with &amp; and change the ConfigProperties to the KRAD version.
