### PR TITLE
KRACOEUS-7408 : Fix back and continue links

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentCoreController.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentCoreController.java
@@ -110,12 +110,6 @@ public class ProposalDevelopmentCoreController extends ProposalDevelopmentContro
 	}
 
 	@MethodAccessible
-	@RequestMapping(value = "/proposalDevelopment", params="methodToCall=navigate")
-	public ModelAndView navigate(@ModelAttribute("KualiForm") ProposalDevelopmentDocumentForm form, BindingResult result, HttpServletRequest request, HttpServletResponse response) {
-		return super.navigate(form, result, request, response);
-	}
-
-	@MethodAccessible
 	@RequestMapping(value = "/proposalDevelopment", params="methodToCall=refresh")
 	public ModelAndView refresh(@ModelAttribute("KualiForm") ProposalDevelopmentDocumentForm form, BindingResult result, HttpServletRequest request, HttpServletResponse response)
 			throws Exception {

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentHomeController.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentHomeController.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.kuali.coeus.common.framework.keyword.ScienceKeyword;
 import org.kuali.coeus.common.framework.sponsor.Sponsor;
 import org.kuali.coeus.common.specialreview.impl.rule.event.SaveDocumentSpecialReviewEvent;
-import org.kuali.coeus.propdev.impl.core.DevelopmentProposal;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentControllerBase;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocument;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocumentForm;
@@ -35,7 +34,6 @@ import org.kuali.kra.bo.ExemptionType;
 import org.kuali.rice.contrib.krad.web.bind.UifCalendarEditor;
 import org.kuali.rice.core.api.criteria.QueryByCriteria;
 import org.kuali.rice.krad.uif.UifParameters;
-import org.kuali.rice.krad.uif.element.Action;
 import org.kuali.rice.krad.web.controller.MethodAccessible;
 import org.kuali.rice.krad.web.form.DocumentFormBase;
 import org.springframework.beans.propertyeditors.CustomCollectionEditor;
@@ -72,30 +70,12 @@ public class ProposalDevelopmentHomeController extends ProposalDevelopmentContro
        return super.save(form, result, request, response);
    }
    
-   @RequestMapping(value = "/proposalDevelopment", params = "methodToCall=saveAndContinue")
-   public ModelAndView saveAndContinue(@ModelAttribute("KualiForm") ProposalDevelopmentDocumentForm form, BindingResult result,
-           HttpServletRequest request, HttpServletResponse response) throws Exception {
-       List<Action> actions = form.getOrderedNavigationActions();
-       int indexOfCurrentAction = form.findIndexOfPageId(actions);
-       if (indexOfCurrentAction == -1) {
-           indexOfCurrentAction = 0;
-       }
-       if (indexOfCurrentAction < actions.size()-1) {
-           form.getActionParameters().put(UifParameters.NAVIGATE_TO_PAGE_ID, actions.get(indexOfCurrentAction+1).getNavigateToPageId());
-       }
-       return save(form, result, request, response);
+   @RequestMapping(value ="/proposalDevelopment", params = "methodToCall=navigate")
+   public ModelAndView navigate(@ModelAttribute("KualiForm") DocumentFormBase form, BindingResult result,
+		   HttpServletRequest request, HttpServletResponse response) throws Exception {
+	   return super.navigate(form, result, request, response);
    }
-   
-   @RequestMapping(value = "/proposalDevelopment", params = "methodToCall=previousPage")
-   public ModelAndView previousPage(@ModelAttribute("KualiForm") ProposalDevelopmentDocumentForm form, BindingResult result,
-           HttpServletRequest request, HttpServletResponse response) throws Exception {
-       List<Action> actions = form.getOrderedNavigationActions();
-       int indexOfCurrentAction = form.findIndexOfPageId(actions);
-       if (indexOfCurrentAction != -1 && indexOfCurrentAction > 0) {
-           form.getActionParameters().put(UifParameters.NAVIGATE_TO_PAGE_ID, actions.get(indexOfCurrentAction-1).getNavigateToPageId());
-       }
-       return navigate(form, result, request, response);
-   }
+		   
    
    @MethodAccessible
    @RequestMapping(value = "/proposalDevelopment", params="methodToCall=getSponsor")

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentConstants.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentConstants.java
@@ -1,0 +1,9 @@
+package org.kuali.coeus.propdev.impl.core;
+
+public class ProposalDevelopmentConstants {
+
+	public static class KradConstants {
+		public static final String PREVIOUS_PAGE_ARG = "previous";
+		public static final String NEXT_PAGE_ARG = "next";
+	}
+}

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
@@ -185,8 +185,10 @@ public abstract class ProposalDevelopmentControllerBase {
          }
      }
      
-     protected ModelAndView navigate(ProposalDevelopmentDocumentForm form, BindingResult result, HttpServletRequest request, HttpServletResponse response) {
-    	 return getTransactionalDocumentControllerService().navigate(form, result, request, response);
+     protected ModelAndView navigate(DocumentFormBase form, BindingResult result, HttpServletRequest request, HttpServletResponse response) throws Exception {
+		form.setPageId(form.getActionParamaterValue(UifParameters.NAVIGATE_TO_PAGE_ID));
+		form.setDirtyForm(false);
+		return save(form, result, request, response);
      }
 
     protected KcAuthorizationService getKraAuthorizationService() {

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentForm.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentForm.java
@@ -85,16 +85,7 @@ public class ProposalDevelopmentDocumentForm extends TransactionalDocumentFormBa
                 return i;
             }
         }
-        return -1;
-    }
-    
-    public boolean canGoBack() {
-        return findIndexOfPageId(getOrderedNavigationActions()) > 0;
-    }
-    
-    public boolean canGoForward() {
-        List<Action> actions = getOrderedNavigationActions();
-        return findIndexOfPageId(actions) < actions.size();
+        return 0;
     }
     
     public List<Action> getOrderedNavigationActions() {

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentViewHelperServiceImpl.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentViewHelperServiceImpl.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.framework.sponsor.Sponsor;
@@ -33,15 +31,15 @@ import org.kuali.coeus.propdev.impl.attachment.Narrative;
 import org.kuali.coeus.propdev.impl.location.AddProposalCongressionalDistrictEvent;
 import org.kuali.coeus.propdev.impl.location.CongressionalDistrict;
 import org.kuali.coeus.propdev.impl.location.ProposalSite;
-import org.kuali.coeus.propdev.impl.person.ProposalPersonUnit;
 import org.kuali.coeus.propdev.impl.person.ProposalPersonDegree;
 import org.kuali.coeus.propdev.impl.person.attachment.ProposalPersonBiography;
 import org.kuali.coeus.propdev.impl.specialreview.ProposalSpecialReview;
 import org.kuali.coeus.propdev.impl.attachment.LegacyNarrativeService;
-import org.kuali.rice.krad.data.DataObjectWrapper;
 import org.kuali.rice.krad.service.KualiRuleService;
 import org.kuali.rice.krad.service.LookupService;
 import org.kuali.rice.krad.uif.UifConstants;
+import org.kuali.rice.krad.uif.UifParameters;
+import org.kuali.rice.krad.uif.element.Action;
 import org.kuali.rice.krad.uif.service.impl.ViewHelperServiceImpl;
 import org.kuali.rice.krad.uif.util.ObjectPropertyUtils;
 import org.kuali.rice.krad.uif.view.ViewModel;
@@ -94,6 +92,22 @@ public class ProposalDevelopmentViewHelperServiceImpl extends ViewHelperServiceI
         }
     }
 
+    public void finalizeNavigationLinks(Action action, Object model, String direction) {
+   	 ProposalDevelopmentDocumentForm pdForm = (ProposalDevelopmentDocumentForm) model;
+   	 List<Action> actions = pdForm.getOrderedNavigationActions();
+   	 int indexOfCurrentAction = pdForm.findIndexOfPageId(actions);
+   	 if (StringUtils.equals(direction, ProposalDevelopmentConstants.KradConstants.PREVIOUS_PAGE_ARG)) {
+   		 action.setRender(indexOfCurrentAction > 0);
+   		 if (indexOfCurrentAction > 0) {
+   			 action.getActionParameters().put(UifParameters.NAVIGATE_TO_PAGE_ID, pdForm.getOrderedNavigationActions().get(indexOfCurrentAction-1).getNavigateToPageId());
+   		 }
+   	 } else if (StringUtils.equals(direction, ProposalDevelopmentConstants.KradConstants.NEXT_PAGE_ARG)) {
+   		 action.setRender(indexOfCurrentAction < actions.size());
+   		 if (indexOfCurrentAction < actions.size()) {
+   			 action.getActionParameters().put(UifParameters.NAVIGATE_TO_PAGE_ID, pdForm.getOrderedNavigationActions().get(indexOfCurrentAction+1).getNavigateToPageId());
+   		 }
+   	 }
+    }    
 
     @Override   
     protected boolean performAddLineValidation(ViewModel viewModel, Object newLine, String collectionId,

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/attachment/ProposalAttachmentsPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/attachment/ProposalAttachmentsPage.xml
@@ -16,7 +16,7 @@
                     http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<bean id="PropDev-AttachmentsPage" parent="PropDev-AttachmentsPage-parentBean" />
-	<bean id="PropDev-AttachmentsPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-AttachmentsPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-AttachmentsPage-TabGroup" p:order="10"/>
@@ -25,9 +25,6 @@
         <property name="header">
             <bean parent="Uif-PageHeader" p:headerText="Attachments" />
         </property>
-		<property name="footer">
-			<null />
-		</property>
     </bean>
 
     <bean id="PropDev-AttachmentsPage-TabGroup" parent="PropDev-AttachmentsPage-TabGroup-parentBean"/>

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalCommon.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalCommon.xml
@@ -12,9 +12,34 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
                     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+	<bean id="PropDev-DocumentPage" parent="PropDev-DocumentPage-parentBean"/>
+	<bean id="PropDev-DocumentPage-parentBean" abstract="true" parent="Uif-DocumentPage">
+		<property name="footer" ref="PropDev-DocumentFooter"/>
+	</bean>
+
+	<bean id="PropDev-DocumentFooter" parent="PropDev-DocumentFooter-parentBean" />
+	<bean id="PropDev-DocumentFooter-parentBean" abstract="true" p:dataAttributes="sticky_footer:true"
+		parent="Uif-FooterBase">
+		<property name="items">
+			<list>
+				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="true"
+					p:performClientSideValidation="true" p:methodToCall="navigate" 
+					p:actionLabel="Back" p:finalizeMethodToCall="finalizeNavigationLinks"
+					p:finalizeMethodAdditionalArguments="previous" p:order="10" />				
+				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
+					p:performClientSideValidation="true" p:methodToCall="save"
+					p:actionLabel="Save" p:order="20" />
+				<bean parent="Uif-PrimaryActionButton" p:ajaxSubmit="true"
+					p:performClientSideValidation="true" p:methodToCall="navigate"
+					p:actionLabel="Save and Continue" p:finalizeMethodToCall="finalizeNavigationLinks"
+					p:finalizeMethodAdditionalArguments="next" p:order="30" />
+			</list>
+		</property>
+	</bean>
+	
 	<bean id="PropDev-UnderDevelopmentPage" parent="PropDev-UnderDevelopmentPage-parentBean" />
 	<bean id="PropDev-UnderDevelopmentPage-parentBean" abstract="true"
-		parent="Uif-DocumentPage">
+		parent="PropDev-DocumentPage">
 		<property name="items">
 			<list merge="false">
 				<bean parent="Uif-HeaderOne" p:headerText="Under Construction" />

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalDetailsPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalDetailsPage.xml
@@ -14,7 +14,7 @@
 
 	<!-- Proposal Details Page -->
 	<bean id="PropDev-DetailsPage" parent="PropDev-DetailsPage-parentBean" />
-	<bean id="PropDev-DetailsPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-DetailsPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-DetailsPage-Section" p:order="10" />
@@ -30,9 +30,6 @@
 					</list>
 				</property>
 			</bean>
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalDocumentView.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalDocumentView.xml
@@ -39,7 +39,7 @@
 			</list>
 		</property>
 		<property name="header" ref="PropDev-DocumentHeader" />
-		<property name="footer" ref="PropDev-DocumentFooter" />
+		<property name="footer"><null/></property>
 		<property name="navigation" ref="PropDev-Menu" />
 		<property name="entryPageId" value="PropDev-DetailsPage"/>
 		<property name="items">
@@ -71,25 +71,6 @@
 		<property name="dialogs">
 			<list>
 				<ref bean="PropDev-PersonnelPage-Wizard" />
-			</list>
-		</property>
-	</bean>
-
-	<bean id="PropDev-DocumentFooter" parent="PropDev-DocumentFooter-parentBean" />
-	<bean id="PropDev-DocumentFooter-parentBean" abstract="true"
-		parent="Uif-FooterBase">
-		<property name="items">
-			<list>
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
-					p:methodToCall="previousPage" p:actionLabel="Back" p:render="@{canGoBack()}"
-					p:order="10" />
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="true" p:methodToCall="save"
-					p:actionLabel="Save" p:order="20" />
-				<bean parent="Uif-PrimaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="true" p:methodToCall="saveAndContinue"
-					p:actionLabel="Save and Continue" p:render="@{canGoForward()}"
-					p:order="30" />
 			</list>
 		</property>
 	</bean>

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/deliver/ProposalDeliveryInfoPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/deliver/ProposalDeliveryInfoPage.xml
@@ -16,14 +16,11 @@
 	<!-- Proposal DeliveryInfo Page -->
 	<bean id="PropDev-DeliveryInfoPage" parent="PropDev-DeliveryInfoPage-parentBean"
 		p:header.headerText="Delivery Info" />
-	<bean id="PropDev-DeliveryInfoPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-DeliveryInfoPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-DeliveryInfoPage-Section" p:order="10" />
 			</list>
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/location/ProposalOrganizationLocationsPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/location/ProposalOrganizationLocationsPage.xml
@@ -14,7 +14,7 @@
 
 
 	<bean id="PropDev-OrganizationLocationsPage" parent="PropDev-OrganizationLocationsPage-parentBean" />
-	<bean id="PropDev-OrganizationLocationsPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-OrganizationLocationsPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-OrganizationLocationsPage-Group" p:order="10" />

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
@@ -13,7 +13,7 @@
                     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="PropDev-PersonnelPage" parent="PropDev-PersonnelPage-parentBean" />
-	<bean id="PropDev-PersonnelPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-PersonnelPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<ref bean="PropDev-PersonnelPage-Section" />
@@ -21,9 +21,6 @@
 		</property>
 		<property name="header">
 			<bean parent="Uif-PageHeader" />
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/question/ProposalQuestionnairePage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/question/ProposalQuestionnairePage.xml
@@ -25,7 +25,7 @@
                     http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
     <bean id="PropDev-QuestionnairePage" parent="PropDev-QuestionnairePage-parentBean"/>
-    <bean id="PropDev-QuestionnairePage-parentBean" parent="Uif-DocumentPage">
+    <bean id="PropDev-QuestionnairePage-parentBean" parent="PropDev-DocumentPage">
         <property name="items">
             <list>
                 <bean parent="PropDev-QuestionnairePage-Section" p:order="10"/>
@@ -33,9 +33,6 @@
         </property>
         <property name="header">
             <bean parent="Uif-PageHeader"/>
-        </property>
-        <property name="footer">
-            <null/>
         </property>
     </bean>
 		

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/s2s/ProposalOpportunitySearchPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/s2s/ProposalOpportunitySearchPage.xml
@@ -14,7 +14,7 @@
 
 	<!-- Opportunity Search Page -->
 	<bean id="PropDev-OpportunityPage" parent="PropDev-OpportunityPage-parentBean" />
-	<bean id="PropDev-OpportunityPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-OpportunityPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-OpportunityPage-SearchSection" p:order="10"/>
@@ -24,9 +24,6 @@
 		</property>
 		<property name="header">
 			<bean parent="Uif-PageHeader" p:headerText="Opportunity Search" />
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/specialreview/ProposalCompliancePage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/specialreview/ProposalCompliancePage.xml
@@ -17,7 +17,7 @@
 
 	<!-- Proposal Compliance Page -->
 	<bean id="PropDev-CompliancePage" parent="PropDev-CompliancePage-parentBean" />
-	<bean id="PropDev-CompliancePage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-CompliancePage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<ref bean="PropDev-CompliancePage-Section" />
@@ -25,9 +25,6 @@
 		</property>
 		<property name="header">
 			<bean parent="Uif-PageHeader" />
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/sponsor/ProposalSponsorProgramInfoPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/sponsor/ProposalSponsorProgramInfoPage.xml
@@ -14,7 +14,7 @@
 
 			
 	<bean id="PropDev-SponsorProgramInfoPage" parent="PropDev-SponsorProgramInfoPage-parentBean" p:header.headerText="Sponsor &amp; Program Information" />
-	<bean id="PropDev-SponsorProgramInfoPage-parentBean" parent="Uif-DocumentPage">
+	<bean id="PropDev-SponsorProgramInfoPage-parentBean" parent="PropDev-DocumentPage">
 		<property name="items">
 			<list>
 				<bean parent="PropDev-SponsorProgramInfo-DefaultDetailsSection" p:order="10" />
@@ -22,9 +22,6 @@
 		</property>
 		<property name="header">
 			<bean parent="Uif-PageHeader"  />
-		</property>
-		<property name="footer">
-			<null />
 		</property>
 	</bean>
 		

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
@@ -13,7 +13,7 @@
                     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
     <bean id="PropDev-SupplementalPage" parent="PropDev-SupplementalPage-parentBean" />
-    <bean id="PropDev-SupplementalPage-parentBean" parent="Uif-DocumentPage">
+    <bean id="PropDev-SupplementalPage-parentBean" parent="PropDev-DocumentPage">
         <property name="items">
             <list>
                 <bean parent="PropDev-Supplemental-Collection"></bean>
@@ -21,9 +21,6 @@
         </property>
         <property name="header">
             <bean parent="Uif-PageHeader" p:headerText="Supplemental Info" />
-        </property>
-        <property name="footer">
-            <null />
         </property>
     </bean>
 


### PR DESCRIPTION
The back and continue links don't work correctly for 2 reasons.
- It causes NPEs due to the addition of custom action links for custom data.
- They didn't refresh with the page meaning their rendering or not were often out of date.

This fixes both issues by moving the links out of document footer into the page footer and using finalizeMethodToCall to build the links and the correct navigateToPageIds.
