### PR TITLE
KRACOEUS-6955 : remove old hard coded classnames (Sponsor, Unit, ResearchArea)

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/common/committee/impl/lookup/CommitteeLookupableHelperServiceImplBase.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/common/committee/impl/lookup/CommitteeLookupableHelperServiceImplBase.java
@@ -24,6 +24,7 @@ import org.kuali.coeus.common.committee.impl.bo.CommitteeResearchAreaBase;
 import org.kuali.coeus.common.committee.impl.document.CommitteeDocumentBase;
 import org.kuali.coeus.sys.framework.auth.perm.KcAuthorizationService;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
+import org.kuali.kra.irb.ResearchArea;
 import org.kuali.kra.lookup.KraLookupableHelperServiceImpl;
 import org.kuali.coeus.common.questionnaire.framework.question.Question;
 import org.kuali.rice.kew.api.KewApiConstants;
@@ -66,7 +67,6 @@ public abstract class CommitteeLookupableHelperServiceImplBase<CMT extends Commi
         fieldValues.put(COMMITTEE_TYPE_CODE_FIELD_NAME, getCommitteeTypeCodeHook());
         List<CMT> activeCommittees =  (List<CMT>)getUniqueList(super.getSearchResultsUnbounded(fieldValues), fieldValues);
         Long matchingResultsCount = new Long(activeCommittees.size());
-        // TODO should the Question.class be replaced by a committee class below?
         Integer searchResultsLimit = LookupUtils.getSearchResultsLimit(Question.class);
         
         if ((matchingResultsCount == null) || (matchingResultsCount.intValue() <= searchResultsLimit.intValue())) {
@@ -91,7 +91,7 @@ public abstract class CommitteeLookupableHelperServiceImplBase<CMT extends Commi
         for (Row row : rows) {
             for (Field field : row.getFields()) {
                 if (field.getPropertyName().equals("committeeResearchAreas.researchAreaCode")) {
-                    super.updateLookupField(field,RESEARCH_AREA_CODE,"org.kuali.kra.bo.ResearchArea");
+                    super.updateLookupField(field,RESEARCH_AREA_CODE,ResearchArea.class.getName());
                 } else if (field.getPropertyName().equals("committeeMemberships.personName")) {
                     super.updateLookupField(field,PERSON_NAME, getCommitteeMembershipFullyQualifiedClassNameHook());
                 }

--- a/coeus-code/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationLookupableHelperServiceImpl.java
+++ b/coeus-code/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationLookupableHelperServiceImpl.java
@@ -16,6 +16,8 @@
 package org.kuali.kra.negotiations.lookup;
 
 import org.apache.commons.lang3.StringUtils;
+import org.kuali.coeus.common.framework.sponsor.Sponsor;
+import org.kuali.coeus.common.framework.unit.Unit;
 import org.kuali.kra.lookup.KraLookupableHelperServiceImpl;
 import org.kuali.kra.negotiations.bo.Negotiation;
 import org.kuali.rice.kew.api.KewApiConstants;
@@ -148,8 +150,7 @@ public class NegotiationLookupableHelperServiceImpl extends KraLookupableHelperS
                 }
                 if (StringUtils.equalsIgnoreCase(column.getPropertyName(), leadUnitNumber)){
                     String unitNumber = column.getPropertyValue();
-                    //String newUrl = "http://127.0.0.1:8080/kc-dev/kr/inquiry.do?businessObjectClassName=org.kuali.kra.bo.Unit&unitNumber=" + unitNumber + "&methodToCall=start";
-                    String newUrl = "inquiry.do?businessObjectClassName=org.kuali.kra.bo.Unit&unitNumber=" + unitNumber + "&methodToCall=start";
+                    String newUrl = "inquiry.do?businessObjectClassName="+ Unit.class.getName()+"&unitNumber=" + unitNumber + "&methodToCall=start";
                     column.setPropertyURL(newUrl);
                     for (AnchorHtmlData data : column.getColumnAnchors()) {
                         if (data != null) {
@@ -174,7 +175,7 @@ public class NegotiationLookupableHelperServiceImpl extends KraLookupableHelperS
         for (Row row : getRows()) {
             for (Field field : row.getFields()) {
                 if (StringUtils.equalsIgnoreCase(field.getPropertyName(), "associatedNegotiable.sponsorCode")) {
-                    field.setQuickFinderClassNameImpl("org.kuali.kra.bo.Sponsor");
+                    field.setQuickFinderClassNameImpl(Sponsor.class.getName());
                     field.setFieldConversions("sponsorCode:associatedNegotiable.sponsorCode");
                     field.setLookupParameters("");
                     field.setBaseLookupUrl(LookupUtils.getBaseLookupUrl(false));
@@ -182,7 +183,7 @@ public class NegotiationLookupableHelperServiceImpl extends KraLookupableHelperS
                     field.setInquiryParameters("associatedNegotiable.sponsorCode:sponsorCode");
                     field.setFieldDirectInquiryEnabled(true);
                 } else if (StringUtils.equalsIgnoreCase(field.getPropertyName(), "associatedNegotiable.leadUnitNumber")) {
-                    field.setQuickFinderClassNameImpl("org.kuali.kra.bo.Unit");
+                    field.setQuickFinderClassNameImpl(Unit.class.getName());
                     field.setFieldConversions("unitNumber:associatedNegotiable.leadUnitNumber");
                     field.setLookupParameters("");
                     field.setBaseLookupUrl(LookupUtils.getBaseLookupUrl(false));

--- a/coeus-it/src/test/java/org/kuali/kra/committee/service/CommitteeLookupHelperServiceTest.java
+++ b/coeus-it/src/test/java/org/kuali/kra/committee/service/CommitteeLookupHelperServiceTest.java
@@ -19,8 +19,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.kuali.kra.committee.bo.Committee;
+import org.kuali.kra.committee.bo.CommitteeMembership;
 import org.kuali.kra.committee.document.CommitteeDocument;
 import org.kuali.kra.committee.lookup.CommitteeLookupableHelperServiceImpl;
+import org.kuali.kra.irb.ResearchArea;
 import org.kuali.kra.test.infrastructure.KcIntegrationTestBase;
 import org.kuali.rice.kns.lookup.HtmlData;
 import org.kuali.rice.kns.web.ui.Field;
@@ -61,9 +63,9 @@ public class CommitteeLookupHelperServiceTest extends KcIntegrationTestBase {
         for (Row row : rows) {
             for (Field field : row.getFields()) {
                 if (field.getPropertyName().equals("researchAreaCode")) {
-                    assertDropDownField(field, "researchAreaCode", "org.kuali.kra.bo.ResearchArea");
+                    assertDropDownField(field, "researchAreaCode", ResearchArea.class.getName());
                 } else if (field.getPropertyName().equals("memberName")) {
-                     assertDropDownField(field, "personName", "org.kuali.kra.committee.bo.CommitteeMembership");
+                     assertDropDownField(field, "personName", CommitteeMembership.class.getName());
                 }
             }
         }


### PR DESCRIPTION
which should be taken care of when classes moved to common
