### PR TITLE
KRACOEUS-7435: Cannot select Proposal as funding source for protocol

### DIFF
--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
@@ -100,13 +100,6 @@
         <property name="lookupableHelperService" ref="lookupableDevelopmentProposalLookupableHelperService" />
     </bean>
 
-    <bean id="lookupableDevelopmentProposalLookupableHelperService" class="org.kuali.coeus.propdev.impl.core.LookupableDevelopmentProposalLookupableHelperServiceImpl"
-          scope="prototype">
-        <property name="proposalPersonDao" ref="proposalPersonDao" />
-        <property name="businessObjectService" ref="businessObjectService" />
-        <property name="documentService" ref="documentService" />
-    </bean>
-
     <bean id="kcCoreCallbackService" abstract="true" class="org.kuali.rice.ksb.api.bus.support.CallbackServiceExporter"
           p:serviceBus-ref="rice.ksb.serviceBus">
         <property name="serviceNameSpaceURI">


### PR DESCRIPTION
Fixed typo in KcKualiLookupableHelperService which was preventing the BusinessObjectService from wiring.  I also added the bean defs for service lookupableDevelopmentProposalLookupableHelperService, that had been removed during refactoring of services.
