### PR TITLE
KRACOEUS-7646: Extended Attributes maint doc does not render properly

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/common/framework/person/attr/PersonCustomData.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/common/framework/person/attr/PersonCustomData.java
@@ -34,6 +34,11 @@ public class PersonCustomData extends KcPersistableBusinessObjectBase implements
         return personCustomDataId;
     }
 
+    // putting in getter for "id" since custom data jsp/tag files are expecting it
+    public Long getId() {
+        return personCustomDataId;
+    }
+
     public void setPersonCustomDataId(Long personCustomDataId) {
         this.personCustomDataId = personCustomDataId;
     }

--- a/coeus-code/src/main/java/org/kuali/coeus/common/impl/person/attr/KcPersonExtendedAttributesMaintainableImpl.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/common/impl/person/attr/KcPersonExtendedAttributesMaintainableImpl.java
@@ -219,7 +219,7 @@ public class KcPersonExtendedAttributesMaintainableImpl extends KraMaintainableI
         }
     }
 
-    protected CustomDataHelper getCustomDataHelper() {
+    public CustomDataHelper getCustomDataHelper() {
         return customDataHelper;
     }
 


### PR DESCRIPTION
Person Extended Attributes maint doc was not rendering properly.  Fixed 2 things:
1)  getCustomDataHelper() method was declared as protected, so JSP was not finding it.
2) getId() was not defined within PersonCustomData class, as the PK was changed from id to personCustomDataId.  So I put in a getId() method to return the personCustomDataId.
