### PR TITLE
KRACOUES-7531:fixed issue with incorrect view path after adding key pers...

### DIFF
--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
@@ -255,7 +255,7 @@
 							p:actionParameters="PropDev-PersonnelPage-Wizard.step:1" p:order="10" />
 						<bean parent="PropDev-PersonnelPage-WizardButton-Continue"
 							p:actionParameters="PropDev-PersonnelPage-Wizard.step:2"
-							p:actionLabel="Add Person" p:refreshId="PropDev-PersonnelPage-Section"
+							p:actionLabel="Add Person" p:ajaxSubmit="false"
 							p:methodToCall="addPerson" p:successCallback="dismissDialog('PropDev-PersonnelPage-Wizard');"
 							p:order="20" />
 					</list>


### PR DESCRIPTION
...on

had a weird issue where view path for the items in the key person collection had a incorrect viewpath starting with dialog[3] instead of currentpage.  changed the add person button on the add person wizard to refresh the page, which corrects the view path, otherwise we weren't able to add anything to the degree collection with out navigating away from the the key personnel panel first.
