### PR TITLE
Set document key as object id in document next value for budget

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/common/budget/framework/core/Budget.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/common/budget/framework/core/Budget.java
@@ -728,7 +728,7 @@ public class Budget extends AbstractBudget implements BudgetContract {
         if (propNextValue == 1) {
             BusinessObjectService bos = KcServiceLocator.getService(BusinessObjectService.class);
             Map<String, Object> pkMap = new HashMap<String, Object>();
-            pkMap.put("documentKey", getBudgetId());
+            pkMap.put("documentKey", this.getObjectId());
             pkMap.put("propertyName", propertyName);
             DocumentNextvalue documentNextvalue = (DocumentNextvalue) bos.findByPrimaryKey(DocumentNextvalue.class, pkMap);
             if (documentNextvalue != null) {
@@ -743,7 +743,7 @@ public class Budget extends AbstractBudget implements BudgetContract {
             DocumentNextvalue documentNextvalue = new DocumentNextvalue();
             documentNextvalue.setNextValue(propNextValue + 1);
             documentNextvalue.setPropertyName(propertyName);
-            documentNextvalue.setDocumentKey(getDocumentNumber());
+            documentNextvalue.setDocumentKey(this.getObjectId());
             getDocumentNextvalues().add(documentNextvalue);
         }
         setDocumentNextvalues(getDocumentNextvalues());


### PR DESCRIPTION
Set document key as object id in document next value
since document number is not available in budget.
Fix to save budget
