### PR TITLE
KRACOEUS-7733: Fixing STE on save when invalid sponsor

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentForm.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentForm.java
@@ -216,7 +216,9 @@ public class ProposalDevelopmentDocumentForm extends TransactionalDocumentFormBa
     	 MedusaNode rootNode = new MedusaNode();
     	 rootNode.setNodeLabel("Medusa Tree");
     	 tree.setRootElement(rootNode);
-    	 rootNode.setChildNodes(getMedusaService().getMedusaByProposal("DP", Long.valueOf(getDevelopmentProposal().getProposalNumber())));
+         if (getDevelopmentProposal().getProposalNumber() != null) {
+             rootNode.setChildNodes(getMedusaService().getMedusaByProposal("DP", Long.valueOf(getDevelopmentProposal().getProposalNumber())));
+         }
     	 return tree;
     }
     


### PR DESCRIPTION
So what was going on here was that KRAD was trying to call the getMedusaTreeView method in order to render the new view after saving but when business rules failed, a null proposal number was being passed in which caused a STE from medusa. I just added a null check which makes sense here. 
