### PR TITLE
KRACOEUS-7117:add key personnel additional work

### DIFF
--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/person/KeyPersonnelAddWizardHelper.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/person/KeyPersonnelAddWizardHelper.java
@@ -39,7 +39,7 @@ public class KeyPersonnelAddWizardHelper {
         personType = "E";
         lookupFieldValues.clear();
         results.clear();
-        personRole = "PI";
+        personRole = null;
     }
 
     public String getPersonType() {

--- a/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/person/ProposalPersonRoleValuesFinder.java
+++ b/coeus-code/src/main/java/org/kuali/coeus/propdev/impl/person/ProposalPersonRoleValuesFinder.java
@@ -1,14 +1,66 @@
 package org.kuali.coeus.propdev.impl.person;
 
+import org.apache.commons.beanutils.PropertyUtils;
+import org.kuali.coeus.common.framework.person.PropAwardPersonRole;
 import org.kuali.coeus.common.framework.person.PropAwardPersonRoleValuesFinder;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocumentForm;
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.krad.uif.field.InputField;
 import org.kuali.rice.krad.uif.view.ViewModel;
 
-public class ProposalPersonRoleValuesFinder extends PropAwardPersonRoleValuesFinder {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
+public class ProposalPersonRoleValuesFinder extends PropAwardPersonRoleValuesFinder {
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PropAwardPersonRoleValuesFinder.class);
 	@Override
 	protected String getSponsorCodeFromModel(ViewModel model) {
 		return ((ProposalDevelopmentDocumentForm) model).getProposalDevelopmentDocument().getDevelopmentProposal().getSponsorCode();
 	}
 
+    @Override
+    public List<KeyValue> getKeyValues(ViewModel model, InputField field){
+        return  getKeyValues(getSponsorCodeFromModel(model), piAlreadyExists(model, field));
+
+    }
+
+    public List<KeyValue> getKeyValues(String sponsorCode,boolean piAlreadyExists) {
+        Collection<PropAwardPersonRole> roles = new ArrayList<PropAwardPersonRole>();
+        roles.addAll(getPropAwardPersonRoleService().getRolesByHierarchy(sponsorCode));
+
+        List<KeyValue> keyValues = new ArrayList<KeyValue>();
+        if (!piAlreadyExists) {
+            addKeyValue(keyValues, roles, PropAwardPersonRole.PRINCIPAL_INVESTIGATOR);
+        }
+        addKeyValue(keyValues, roles, PropAwardPersonRole.MULTI_PI);
+        addKeyValue(keyValues, roles, PropAwardPersonRole.CO_INVESTIGATOR);
+        addKeyValue(keyValues, roles, PropAwardPersonRole.KEY_PERSON);
+        for (PropAwardPersonRole role : roles) {
+            if (role.getCode().equals(PropAwardPersonRole.PRINCIPAL_INVESTIGATOR) && piAlreadyExists) {
+                continue;
+            }
+            addKeyValue(keyValues, role);
+        }
+        return keyValues;
+    }
+
+    protected boolean piAlreadyExists(ViewModel model, InputField field) {
+        try {
+            String roleId = (String) PropertyUtils.getProperty(model, field.getBindingInfo().getBindingPath());
+            if (roleId != null && roleId.equals(PropAwardPersonRole.PRINCIPAL_INVESTIGATOR)) {
+                return false;
+            }
+        } catch (Exception e) {
+            LOG.info("could not retrieve role from the input field ");
+        }
+
+        for (ProposalPerson person : ((ProposalDevelopmentDocumentForm) model).getDevelopmentProposal().getProposalPersons()) {
+            if (person.getRole().getCode().equals(PropAwardPersonRole.PRINCIPAL_INVESTIGATOR)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
+++ b/coeus-code/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
@@ -228,9 +228,9 @@
 		parent="Uif-CssGridSection" p:header.headerText="Assign a role">
 		<property name="items">
 			<list>
-				<bean parent="Uif-InputField" p:required="true"
+				<bean id="PropDev-PersonnelPage-WizardPage3-personRoleRadio" parent="Uif-InputField" p:required="true"
 					p:propertyName="personRole" p:label="Assign a role"
-					p:order="10">
+					p:order="10" p:onDocumentReadyScript="Kc.PropDev.Personnel.selectFirstRadio('#PropDev-PersonnelPage-WizardPage3-personRoleRadio');">
 					<property name="control">
 						<bean parent="Uif-VerticalRadioControl" />
 					</property>

--- a/coeus-webapp/src/main/webapp/scripts/propdev/person.js
+++ b/coeus-webapp/src/main/webapp/scripts/propdev/person.js
@@ -28,4 +28,7 @@ Kc.PropDev.Personnel = Kc.PropDev.Personnel || {};
 		messageSummariesShown = false;
 		return valid;
 	};
+    namespace.selectFirstRadio = function(id) {
+        $(id).find('input').first().prop('checked', true);
+    };
 })(Kc.PropDev.Personnel, jQuery);


### PR DESCRIPTION
1.) removes the PI or PI/contact option is one is already selected
2.) removes person from add key person dialog if they already exist as a key person on the form
3.) sorts the proposalPersons collection when you navigate to the key personnel page or add a key personnel
