### PR TITLE
KRACOEUS-7798 fixing special review approval type values finder

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/compliance/core/SpecialReviewApprovalTypeValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/compliance/core/SpecialReviewApprovalTypeValuesFinder.java
@@ -18,8 +18,10 @@ package org.kuali.coeus.common.impl.compliance.core;
 import org.kuali.coeus.sys.framework.keyvalue.DataObjectValuesFinder;
 import org.kuali.coeus.sys.framework.keyvalue.PrefixValuesFinder;
 import org.kuali.coeus.sys.framework.keyvalue.SortedValuesFinder;
+import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.coeus.common.framework.compliance.core.SpecialReviewApprovalType;
 import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.keyvalues.KeyValuesFinder;
 import org.kuali.rice.krad.keyvalues.PersistableBusinessObjectValuesFinder;
 import org.kuali.rice.krad.uif.control.UifKeyValuesFinderBase;
@@ -52,4 +54,10 @@ public class SpecialReviewApprovalTypeValuesFinder extends DataObjectValuesFinde
         setLabelAttributeName("description");
     }
     
+    public DataObjectService getDataObjectService() {
+    	if (super.getDataObjectService() == null) {
+    		this.setDataObjectService(KcServiceLocator.getService(DataObjectService.class));
+    	}
+    	return super.getDataObjectService();
+    }   
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/specialreview/ProposalSpecialReviewApprovalTypeValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/specialreview/ProposalSpecialReviewApprovalTypeValuesFinder.java
@@ -28,10 +28,12 @@ import org.kuali.rice.core.api.util.KeyValue;
 import org.kuali.rice.krad.uif.field.InputField;
 import org.kuali.rice.krad.uif.util.ObjectPropertyUtils;
 import org.kuali.rice.krad.uif.view.ViewModel;
+import org.springframework.stereotype.Component;
 
 /**
  * See {@link #getKeyValues()}.
  */
+@Component("proposalSpecialReviewApprovalTypeValuesFinder")
 public class ProposalSpecialReviewApprovalTypeValuesFinder extends SpecialReviewApprovalTypeValuesFinder {
     
     /**

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
@@ -834,6 +834,4 @@
         <property name="addBlankOption" value="false"/>
     </bean>
     
-    <bean id="proposalSpecialReviewApprovalTypeValuesFinder" class="org.kuali.coeus.propdev.impl.specialreview.ProposalSpecialReviewApprovalTypeValuesFinder"/>
-    
 </beans>


### PR DESCRIPTION
I tried setting the dataobjectservice as a singleton in various spring bean files to get the autowireing to work without success.  If there is another thing to try please let me know.  Otherwise using the KCServicelocator fixed the problem of the null services.
