### PR TITLE
KRACOEUS-7751: Cannot complete Manual COI Disclosure

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/PersonFinIntDisclosure.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/PersonFinIntDisclosure.xml
@@ -267,14 +267,14 @@
       <bean parent="NumericPatternConstraint"/>
     </property>
     	<property name="control" >
-      <bean parent="SelectControlDefinition" p:businessObjectClass="org.kuali.coeus.common.framework.org.type.OrganizationTypeList" p:valuesFinderClass="org.kuali.coeus.sys.framework.keyvalue.ExtendedPersistableBusinessObjectValuesFinder" p:includeKeyInLabel="false" p:includeBlankRow="false" p:keyAttribute="organizationTypeCode" p:labelAttribute="description"/>
+      <bean parent="SelectControlDefinition" p:businessObjectClass="org.kuali.coeus.common.framework.org.type.OrganizationTypeList" p:valuesFinderClass="org.kuali.coeus.sys.framework.keyvalue.ExtendedPersistableBusinessObjectValuesFinder" p:includeKeyInLabel="false" p:includeBlankRow="false" p:keyAttribute="code" p:labelAttribute="description"/>
     </property>
     <property name="optionsFinder">
       <bean class="org.kuali.coeus.sys.framework.keyvalue.ExtendedPersistableBusinessObjectValuesFinder">
         <property name="businessObjectClass" value="org.kuali.coeus.common.framework.org.type.OrganizationTypeList"/>
         <property name="includeKeyInDescription" value="false"/>
         <property name="includeBlankRow" value="false"/>
-        <property name="keyAttributeName" value="organizationTypeCode"/>
+        <property name="keyAttributeName" value="code"/>
         <property name="labelAttributeName" value="description"/>
       </bean>
     </property>


### PR DESCRIPTION
Another case where the conversion to JPA has resulted in a mismatch between the id of the referenced object (in this case, organizationTypeCode vs. code).
