### PR TITLE
KRACOEUS-7406:fixed lookups using the wrong dataObjectClass

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentViewHelperServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentViewHelperServiceImpl.java
@@ -20,10 +20,7 @@ import java.sql.Timestamp;
 import java.util.*;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.lang3.ClassUtils;
-import org.kuali.coeus.common.framework.custom.arg.ArgValueLookup;
 import org.kuali.coeus.common.framework.krms.KrmsRulesExecutionService;
-import org.kuali.coeus.common.framework.person.KcPerson;
 import org.kuali.coeus.common.questionnaire.framework.answer.AnswerHeader;
 import org.kuali.coeus.common.questionnaire.framework.question.Question;
 import org.kuali.coeus.common.questionnaire.framework.question.QuestionExplanation;
@@ -36,7 +33,6 @@ import org.kuali.coeus.propdev.impl.questionnaire.ProposalDevelopmentQuestionnai
 import org.kuali.coeus.propdev.impl.s2s.question.ProposalDevelopmentS2sQuestionnaireHelper;
 import org.kuali.coeus.sys.framework.validation.AuditHelper;
 import org.kuali.kra.krms.KcKrmsConstants;
-import org.kuali.rice.core.api.exception.RiceRuntimeException;
 import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kew.api.document.DocumentStatus;
 import org.apache.commons.lang3.StringUtils;
@@ -278,37 +274,6 @@ public class ProposalDevelopmentViewHelperServiceImpl extends ViewHelperServiceI
             result.add(new SponsorSuggestResult(sponsor));
         }
         return result;
-    }
-
-    public List<String> performCustomDataFieldSuggest(String dataObjectClass, String searchCriteria, String value) {
-        List<String> results = new ArrayList<String>();
-        Class clazz = null;
-        try {
-            clazz = ClassUtils.getClass(dataObjectClass);
-        } catch (Exception e) {
-            throw new RiceRuntimeException("Custom data object class does not exist",e);
-        }
-        String searchString = "%" + value + "%";
-        Collection<? extends Object> searchResults = new ArrayList<Object>();
-        if (clazz == KcPerson.class) {
-            searchCriteria="principalName";
-            searchResults = getPersonService().findPeople(Collections.singletonMap(searchCriteria, searchString));
-        } else if (clazz == ArgValueLookup.class) {
-            searchResults = getLegacyDataAdapter().findMatching(clazz,Collections.singletonMap("argumentName",searchCriteria));
-            searchCriteria = "value";
-        } else {
-            searchResults = getDataObjectService().findMatching(clazz, QueryByCriteria.Builder.fromPredicates(PredicateFactory.likeIgnoreCase(searchCriteria,searchString))).getResults();
-        }
-
-        for (Object object : searchResults) {
-
-            try {
-                results.add(PropertyUtils.getNestedProperty(object, searchCriteria).toString());
-            } catch (Exception e) {
-                LOG.error("object does not contains search field",e);
-            }
-        }
-        return results;
     }
 
     public boolean isAttachmentEditable(String selectedCollectionPath, String index, HashMap<String,List<String>> editableAttachments) {

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/custom/ProposalDevelopmentCustomDataField.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/custom/ProposalDevelopmentCustomDataField.java
@@ -1,0 +1,55 @@
+package org.kuali.coeus.propdev.impl.custom;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.coeus.common.framework.custom.arg.ArgValueLookup;
+import org.kuali.coeus.common.framework.custom.attr.CustomAttributeDocValue;
+import org.kuali.coeus.common.framework.person.KcPerson;
+import org.kuali.coeus.common.impl.custom.arg.ArgValueLookupValuesFinder;
+import org.kuali.kra.web.krad.KcBindingInfo;
+import org.kuali.rice.kim.impl.identity.principal.PrincipalBo;
+import org.kuali.rice.krad.uif.control.Control;
+import org.kuali.rice.krad.uif.control.TextControlBase;
+import org.kuali.rice.krad.uif.field.InputFieldBase;
+import org.kuali.rice.krad.uif.util.ComponentFactory;
+import org.kuali.rice.krad.uif.util.LifecycleElement;
+import org.kuali.rice.krad.uif.util.ObjectPropertyUtils;
+
+
+public class ProposalDevelopmentCustomDataField extends InputFieldBase {
+
+    @Override
+    public void performApplyModel(Object model, LifecycleElement parent) {
+        Object myBo = ObjectPropertyUtils.getPropertyValue(model, KcBindingInfo.getParentBindingInfo(getBindingInfo()));
+        CustomAttributeDocValue customData = (CustomAttributeDocValue) myBo;
+
+        if (StringUtils.isNotBlank(customData.getCustomAttribute().getLookupClass())) {
+            if (customData.getCustomAttribute().getLookupClass().equals(ArgValueLookup.class.getName())) {
+                setControl((Control) ComponentFactory.getNewComponentInstance("Uif-DropdownControl"));
+                ArgValueLookupValuesFinder valuesFinder = new ArgValueLookupValuesFinder();
+                valuesFinder.setArgName(customData.getCustomAttribute().getLookupReturn());
+                valuesFinder.setAddBlankOption(false);
+                setOptionsFinder(valuesFinder);
+            } else {
+                if (customData.getCustomAttribute().getLookupClass().equals(KcPerson.class.getName())) {
+                    if (customData.getCustomAttribute().getLookupReturn().equals("userName")) {
+                        getSuggest().getSuggestQuery().setDataObjectClassName(PrincipalBo.class.getName());
+                        getSuggest().setValuePropertyName("principalName");
+                        getSuggest().setRender(true);
+                    }
+                } else {
+                    getSuggest().setValuePropertyName(customData.getCustomAttribute().getLookupReturn());
+                    getSuggest().getSuggestQuery().setDataObjectClassName(customData.getCustomAttribute().getLookupClass());
+                    getSuggest().setRender(true);
+                }
+
+                getQuickfinder().setRender(true);
+                getQuickfinder().setDataObjectClassName(customData.getCustomAttribute().getLookupClass());
+                getQuickfinder().getFieldConversions().put(customData.getCustomAttribute().getLookupReturn(), getPropertyName());
+            }
+        } else if (customData.getCustomAttribute().getDataTypeCode().equals("3")) {
+            setControl((Control) ComponentFactory.getNewComponentInstance("Uif-DateControlOnFocus"));
+            ((TextControlBase)getControl()).setWatermarkText("mm/dd/yyyy");
+        }
+        super.performApplyModel(model, parent);
+    }
+}

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
@@ -53,54 +53,15 @@
             p:renderAddLine="false">
         <property name="items">
             <list>
-                <bean parent="Uif-InputField" p:fieldLabel.labelText="@{#line.customAttribute ne null ? #line.customAttribute.label : &quot;Custom Attribute&quot;}" p:propertyName="value">
-                    <property name="propertyReplacers">
-                        <list>
-                            <bean parent="Uif-ConditionalBeanPropertyReplacer"
-                                  p:propertyName="quickfinder"
-                                  p:condition="!#empty(#line.customAttribute.lookupClass)">
-                                <property name="replacement">
-                                    <bean parent="Uif-QuickFinderByScript" p:dataObjectClassName="@{#line.customAttribute.lookupClass}"
-                                          p:fieldConversions="@{#line.customAttribute.lookupReturn}:value"/>
-                                </property>
-                            </bean>
-                            <bean parent="Uif-ConditionalBeanPropertyReplacer"
-                                  p:propertyName="quickfinder"
-                                  p:condition="#line.customAttribute.lookupClass eq 'org.kuali.coeus.common.framework.custom.arg.ArgValueLookup'">
-                                <property name="replacement">
-                                    <bean parent="Uif-QuickFinderByScript" p:dataObjectClassName="@{#line.customAttribute.lookupClass}"
-                                          p:lookupParameters="customAttribute.lookupReturn:argumentName"
-                                          p:fieldConversions="value:value"/>
-                                </property>
-                            </bean>
-                            <bean parent="Uif-ConditionalBeanPropertyReplacer"
-                                  p:propertyName="suggest"
-                                  p:condition="!#empty(#line.customAttribute.lookupClass)">
-                                <property name="replacement">
-                                    <bean parent="Uif-Suggest" p:render="true"
-                                          p:valuePropertyName="value"
-                                          p:returnFullQueryObject="true">
-                                        <property name="templateOptions">
-                                            <map>
-                                                <entry key="minLength" value="1" />
-                                                <entry key="delay" value="1" />
-                                                <entry key="html" value="true" />
-                                            </map>
-                                        </property>
-                                        <property name="suggestQuery">
-                                            <bean parent="Uif-AttributeQueryConfig" p:queryMethodToCall="performCustomDataFieldSuggest" p:queryMethodArgumentFieldList="customAttribute.lookupClass,customAttribute.lookupReturn" />
-                                        </property>
-                                    </bean>
-                                </property>
-                            </bean>
-                            <bean parent="Uif-ConditionalBeanPropertyReplacer"
-                                  p:propertyName="control"
-                                  p:condition="#line.customAttribute.dataTypeCode eq '3'">
-                                <property name="replacement">
-                                    <bean parent="Uif-DateControlOnFocus" p:watermarkText="mm/dd/yyyy" />
-                                </property>
-                            </bean>
-                        </list>
+                <bean parent="Uif-InputField" class="org.kuali.coeus.propdev.impl.custom.ProposalDevelopmentCustomDataField"
+                      p:fieldLabel.labelText="@{#line.customAttribute ne null ? #line.customAttribute.label : &quot;Custom Attribute&quot;}"
+                      p:propertyName="value">
+
+                    <property name="suggest">
+                        <bean parent="Uif-Suggest" p:render="false" />
+                    </property>
+                    <property name="quickfinder">
+                        <bean parent="Uif-QuickFinder" p:render="false" />
                     </property>
                 </bean>
             </list>
@@ -113,5 +74,4 @@
                   p:expression="#line.customAttribute.groupName eq #groupName"/>
         </property>
     </bean>
-
 </beans>


### PR DESCRIPTION
also change supplemental info fields that used ArgValueLookup as there lookup class to use a dropdown control like in questionnaire, which fixes that issue with lookupparameters not working for their quickfinders.  

also fixed the suggest query so that it will work, I had to add special code if the lookup class was KcPerson to query a persistable class.  Right now, if the lookup class is KcPerson it will only work if the lookup return is userName.  works fine in my testing for other classes that are actually persistable.
