### PR TITLE
KRACOEUS-7849 : Fix budget pages to use correct footer

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
@@ -77,6 +77,7 @@
                 <value>classpath:org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelPage.xml</value>
                 <value>classpath:org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAddProjectPersonnelPage.xml</value>
                 <value>classpath:org/kuali/coeus/propdev/impl/budget/rate/ProposalBudgetRatesPage.xml</value>
+                <value>classpath:org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetCommon.xml</value>
 
                 <!-- Budget Mock View -->
                 <value>classpath:org/kuali/coeus/propdev/impl/budget/mock/ProposalBudgetView.xml</value>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetCommon.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetCommon.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2005-2014 The Kuali Foundation Licensed under the Educational 
+	Community License, Version 2.0 (the "License"); you may not use this file 
+	except in compliance with the License. You may obtain a copy of the License 
+	at http://www.opensource.org/licenses/ecl2.php Unless required by applicable 
+	law or agreed to in writing, software distributed under the License is distributed 
+	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+	express or implied. See the License for the specific language governing permissions 
+	and limitations under the License. -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+                    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+             
+	<bean id="PropBudget-Page" parent="PropBudget-Page-parentBean"/>
+	<bean id="PropBudget-Page-parentBean" abstract="true" parent="Uif-Page">
+		<property name="footer">
+			<bean parent="PropBudget-Footer" p:order="10"/>
+		</property>
+	</bean>      
+	
+	<bean id="PropBudget-Footer" parent="PropBudget-Footer-parentBean" />
+	<bean id="PropBudget-Footer-parentBean" abstract="true" parent="Uif-FooterBase"
+		p:dataAttributes="sticky_footer:true">
+		<property name="items">
+			<list>
+				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false" p:performClientSideValidation="true"
+					p:methodToCall="previousPage" p:actionLabel="Back"
+					p:iconClass="icon-chevron-left" p:actionIconPlacement="LEFT"
+					p:order="10" />
+				<bean parent="Uif-PrimaryActionButton" p:ajaxSubmit="false"
+					p:performClientSideValidation="true" p:methodToCall="saveAndContinue"
+					p:actionLabel="Continue"
+					p:iconClass="icon-chevron-right" p:actionIconPlacement="RIGHT"
+					p:order="20" />					
+				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
+					p:performClientSideValidation="true" p:methodToCall="save"
+					p:actionLabel="Save" p:order="30" />
+				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
+					p:performClientSideValidation="true" p:methodToCall="completeBudget"
+					p:actionLabel="Complete Budget"
+					p:order="50" />
+			</list>
+		</property>
+	</bean>	      
+</beans>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetPeriodsPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetPeriodsPage.xml
@@ -17,7 +17,7 @@
 
 
 	<bean id="PropBudget-PeriodsPage" parent="PropBudget-PeriodsPage-parentBean" />
-	<bean id="PropBudget-PeriodsPage-parentBean" parent="PropDev-DocumentPage" p:fieldBindingObjectPath="budget">
+	<bean id="PropBudget-PeriodsPage-parentBean" parent="PropBudget-Page" p:fieldBindingObjectPath="budget">
 		<property name="items">
 			<list>
 				<ref bean="PropBudget-PeriodsPage-CollectionGroup" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
@@ -54,34 +54,6 @@
 		</property>
 	</bean>
 
-	<bean id="PropBudget-DocumentFooter" parent="PropBudget-DocumentFooter-parentBean" />
-	<bean id="PropBudget-DocumentFooter-parentBean" abstract="true"
-		parent="Uif-FooterBase">
-		<property name="items">
-			<list>
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false" p:performClientSideValidation="true"
-					p:methodToCall="previousPage" p:actionLabel="Back"
-					p:iconClass="icon-chevron-left" p:actionIconPlacement="LEFT"
-					p:order="10" />
-				<bean parent="Uif-PrimaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="true" p:methodToCall="saveAndContinue"
-					p:actionLabel="Continue"
-					p:iconClass="icon-chevron-right" p:actionIconPlacement="RIGHT"
-					p:order="20" />					
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="true" p:methodToCall="save"
-					p:actionLabel="Save" p:order="30" />
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="false" p:methodToCall="reload"
-					p:actionLabel="Reload" p:order="40" />
-				<bean parent="Uif-SecondaryActionButton" p:ajaxSubmit="false"
-					p:performClientSideValidation="true" p:methodToCall="completeBudget"
-					p:actionLabel="Complete Budget"
-					p:order="50" />
-			</list>
-		</property>
-	</bean>
-
 	<bean id="PropBudget-Menu" parent="PropBudget-Menu-parentBean" />
 	<bean id="PropBudget-Menu-parentBean" abstract="true"
 		parent="Uif-MenuNavigationGroup" p:defaultItemIconClass="">

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/income/ProposalBudgetIncomePage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/income/ProposalBudgetIncomePage.xml
@@ -17,7 +17,7 @@
     <!-- Proposal Budget Income Page -->
     <bean id="PropBudget-ProjectIncomePage" parent="PropBudget-ProjectIncomePage-parentBean" />
     <bean id="PropBudget-ProjectIncomePage-parentBean"
-          parent="PropDev-DocumentPage" p:fieldBindingObjectPath="budget">
+          parent="PropBudget-Page" p:fieldBindingObjectPath="budget">
         <property name="items">
             <list>
                 <ref bean="PropBudget-ProjectIncomePage-CollectionGroup" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelPage.xml
@@ -16,7 +16,7 @@
                     http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<bean id="PropBudget-ProjectPersonnelPage" parent="PropBudget-ProjectPersonnelPage-parentBean" />
-	<bean id="PropBudget-ProjectPersonnelPage-parentBean" parent="PropDev-DocumentPage" p:fieldBindingObjectPath="budget">
+	<bean id="PropBudget-ProjectPersonnelPage-parentBean" parent="PropBudget-Page" p:fieldBindingObjectPath="budget">
 		<property name="items">
 			<list>
 				<ref bean="PropBudget-ProjectPersonnelPage-CollectionGroup" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/rate/ProposalBudgetRatesPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/rate/ProposalBudgetRatesPage.xml
@@ -14,7 +14,7 @@
 
 	<bean id="PropBudget-RatesPage" parent="PropBudget-RatesPage-parentBean" />
 	<bean id="PropBudget-RatesPage-parentBean" abstract="true"
-		parent="Uif-DocumentPage">
+		parent="PropBudget-Page">
 		<property name="items">
 			<list>
 				<bean parent="PropBudget-RatesPage-TabGroup" p:order="10"/>
@@ -23,9 +23,6 @@
 		</property>
 		<property name="header">
 			<bean parent="Uif-PageHeader" />
-		</property>
-		<property name="footer">
-			<bean parent="PropBudget-DocumentFooter"/>
 		</property>
 	</bean>
 


### PR DESCRIPTION
Budget pages no longer include a footer from PropDev that causes a STE in non-document views.
