### PR TITLE
KRACOEUS-7867: Fix errors in RegEx validation expressions

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/org/Organization.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/org/Organization.xml
@@ -324,7 +324,7 @@
       <bean p:pattern="^[a-zA-Z][a-zA-Z]-[0-9]{1,3}|[a-zA-Z][a-zA-Z]-all|00-000|US-all$" p:validationErrorMessageKey="error.congressionalDistrict.format" parent="RegexValidationPattern"/>
     </property>
     <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
+      <bean parent="ValidCharactersConstraint">
         <property name="value" value="^[a-zA-Z][a-zA-Z]-[0-9]{1,3}|[a-zA-Z][a-zA-Z]-all|00-000|US-all$"/>
         <property name="messageKey" value="error.congressionalDistrict.format"/>
       </bean>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/core/DevelopmentProposal.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/core/DevelopmentProposal.xml
@@ -365,22 +365,13 @@
 	</bean>
 
 	<bean id="DevelopmentProposal-currentAwardNumber" parent="DevelopmentProposal-currentAwardNumber-parentBean" />
-        <bean id="DevelopmentProposal-currentAwardNumber-parentBean" abstract="true" parent="Award-awardNumber-parentBean">
+        <bean id="DevelopmentProposal-currentAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber">
 		<property name="name" value="currentAwardNumber" />
 		<property name="label" value="Award ID" />
 		<property name="shortLabel" value="Award ID" />
 		<property name="required" value="false" />
 		<property name="summary" value="The Sponsor Award Number for this Proposal." />
                 <property name="description" value="A unique institutionally assigned number of a previously funded application."/>
-		<property name="validationPattern">
-                        <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.missing"/>
-                </property>
-                <property name="validCharactersConstraint">
-                        <bean parent="JavaClassPatternConstraint">
-                                <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
-                                <property name="messageKey" value="error.missing"/>
-                        </bean>
-		</property>
 	</bean>
 
 	<bean id="DevelopmentProposal-continuedFrom" parent="DevelopmentProposal-continuedFrom-parentBean" />

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
@@ -372,28 +372,11 @@
   </bean>
 
 <bean id="Award-awardNumber" parent="Award-awardNumber-parentBean" />
-  <bean id="Award-awardNumber-parentBean" abstract="true" parent="AttributeDefinition">
+  <bean id="Award-awardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber">
     <property name="name" value="awardNumber" />
-    <property name="forceUppercase" value="false" />
     <property name="label" value="Award ID" />
     <property name="shortLabel" value="Award ID" />
-    <property name="maxLength" value="12" />
-    <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    </property>
     <property name="required" value="false" />
-    <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-    </property>
     <property name="summary" value="Award ID" />
     <property name="description" value="Award ID" />
   </bean>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/AwardHierarchy.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/AwardHierarchy.xml
@@ -41,27 +41,11 @@
 
     <!-- Attribute Definitions -->
     <bean id="AwardHierarchy-rootAwardNumber" parent="AwardHierarchy-rootAwardNumber-parentBean" />
-    <bean id="AwardHierarchy-rootAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="AwardHierarchy-rootAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="rootAwardNumber" />
         <property name="forceUppercase" value="false" />
         <property name="label" value="Root  Award Number" />
         <property name="shortLabel" value="Root  Award Number" />
-        <property name="maxLength" value="12" />
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-	    </property>
-        <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-        </property>
         <property name="summary" value="Root  Award Number" />
         <property name="description" value="Root  Award Number" />
     </bean>
@@ -69,27 +53,10 @@
     <bean id="AwardHierarchy-awardNumber" parent="AwardHierarchy-awardNumber-parentBean" />
   <bean id="AwardHierarchy-awardNumber-parentBean" abstract="true" parent="Award-awardNumber"/>
     <bean id="AwardHierarchy-parentAwardNumber" parent="AwardHierarchy-parentAwardNumber-parentBean" />
-    <bean id="AwardHierarchy-parentAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="AwardHierarchy-parentAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="parentAwardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Parent  Award Number" />
         <property name="shortLabel" value="Parent  Award Number" />
-        <property name="maxLength" value="12" />
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-	    </property>
-        <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-        </property>
         <property name="summary" value="Parent  Award Number" />
         <property name="description" value="Parent  Award Number" />
     </bean>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/CommitteeScheduleAttributeReferenceDummy.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/CommitteeScheduleAttributeReferenceDummy.xml
@@ -181,7 +181,7 @@
       <bean parent="RegexValidationPattern" p:pattern="(([0][1-9])|([1][0-2])):[0-5][0-9]" p:validationErrorMessageKey="error.committeeSchedule.viewtime"/>
     </property>
     <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
+      <bean parent="ValidCharactersConstraint">
         <property name="value" value="(([0][1-9])|([1][0-2])):[0-5][0-9]"/>
         <property name="messageKey" value="error.committeeSchedule.viewtime"/>
       </bean>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/KraAttributeReferenceDummy.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/KraAttributeReferenceDummy.xml
@@ -533,5 +533,32 @@
 		<property name="summary" value="Sponsor/S2S" />
 		<property name="description" value="Sponsor/S2S" />
 	</bean>
-  
+
+    <bean id="KraAttributeReferenceDummy-awardNumber" parent="KraAttributeReferenceDummy-awardNumber-parentBean" />
+    <bean id="KraAttributeReferenceDummy-awardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+        <property name="name" value="Award Number" />
+        <property name="label" value="Award Number" />
+        <property name="shortLabel" value="Award Number" />
+        <property name="forceUppercase" value="false" />
+        <property name="maxLength" value="12" />
+        <property name="validationPattern" >
+            <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
+        </property>
+        <property name="validCharactersConstraint">
+            <bean parent="JavaClassPatternConstraint">
+                <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
+                <property name="messageKey" value="error.invalid.awardId"/>
+            </bean>
+        </property>
+        <property name="control" >
+            <bean parent="TextControlDefinition" p:size="12"/>
+        </property>
+        <property name="controlField">
+            <bean p:size="12" parent="Uif-TextControl"/>
+        </property>
+        <property name="summary" value="Award Number" />
+        <property name="description" value="Award Number" />
+    </bean>
+
+
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/PendingTransaction.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/PendingTransaction.xml
@@ -73,61 +73,39 @@
     </bean>
 
     <bean id="PendingTransaction-sourceAwardNumber" parent="PendingTransaction-sourceAwardNumber-parentBean" />
-    <bean id="PendingTransaction-sourceAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="PendingTransaction-sourceAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="sourceAwardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Source Award" />
         <property name="shortLabel" value="Source Award" />
-        <property name="maxLength" value="12" />
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    	</property>
         <property name="required" value="true" />
-        <property name="control" >			
-      <bean parent="SelectControlDefinition" p:valuesFinderClass="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder" p:includeKeyInLabel="false"/>
-    </property>
-    <property name="optionsFinder">
-      <bean class="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder"/>
-    </property>
-    <property name="controlField">
-      <bean parent="Uif-DropdownControl"/>
-		</property>
+        <property name="control" >
+            <bean parent="SelectControlDefinition" p:valuesFinderClass="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder" p:includeKeyInLabel="false"/>
+        </property>
+        <property name="optionsFinder">
+          <bean class="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder"/>
+        </property>
+        <property name="controlField">
+          <bean parent="Uif-DropdownControl"/>
+	    </property>
         <property name="summary" value="Source Award" />
         <property name="description" value="Source Award" />
     </bean>
 
     <bean id="PendingTransaction-destinationAwardNumber" parent="PendingTransaction-destinationAwardNumber-parentBean" />
-    <bean id="PendingTransaction-destinationAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="PendingTransaction-destinationAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="destinationAwardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Destination Award" />
         <property name="shortLabel" value="Destination Award" />
-        <property name="maxLength" value="12" />
         <property name="required" value="true" />
-         <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    	</property>
         <property name="control" >			
-      <bean parent="SelectControlDefinition" p:valuesFinderClass="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder" p:includeKeyInLabel="false"/>
-    </property>
-    <property name="optionsFinder">
-      <bean class="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder"/>
-    </property>
-    <property name="controlField">
-      <bean parent="Uif-DropdownControl"/>
-		</property>
+            <bean parent="SelectControlDefinition" p:valuesFinderClass="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder" p:includeKeyInLabel="false"/>
+        </property>
+        <property name="optionsFinder">
+            <bean class="org.kuali.kra.timeandmoney.PendingTransactionAwardValuesFinder"/>
+        </property>
+        <property name="controlField">
+            <bean parent="Uif-DropdownControl"/>
+        </property>
         <property name="summary" value="Destination Award" />
         <property name="description" value="Destination Award" />
     </bean>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/SubAward.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/SubAward.xml
@@ -653,28 +653,11 @@
 	</bean>
 	
   <bean id="SubAward-awardNumber" parent="SubAward-awardNumber-parentBean"/>
-  <bean id="SubAward-awardNumber-parentBean" abstract="true" parent="AttributeDefinition">
+  <bean id="SubAward-awardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber">
     <property name="name" value="awardNumber"/>
-    <property name="forceUppercase" value="false"/>
     <property name="label" value="Award ID"/>
     <property name="shortLabel" value="Award ID"/>
-    <property name="maxLength" value="12"/>
-    <property name="validationPattern">
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    </property>
     <property name="required" value="false"/>
-    <property name="control">
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-    </property>
     <property name="summary" value="Award ID"/>
     <property name="description" value="Award ID"/>
   </bean>

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/TransactionDetail.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/TransactionDetail.xml
@@ -74,28 +74,11 @@
     </bean>
 
     <bean id="TransactionDetail-awardNumber" parent="TransactionDetail-awardNumber-parentBean" />
-    <bean id="TransactionDetail-awardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="TransactionDetail-awardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="awardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Award Number" />
         <property name="shortLabel" value="Award Number" />
-        <property name="maxLength" value="12" />
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    	</property>
         <property name="required" value="true" />
-        <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-        </property>
         <property name="summary" value="Award Number" />
         <property name="description" value="Award Number" />
     </bean>
@@ -171,55 +154,20 @@
     </bean>
 
     <bean id="TransactionDetail-sourceAwardNumber" parent="TransactionDetail-sourceAwardNumber-parentBean" />
-    <bean id="TransactionDetail-sourceAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="TransactionDetail-sourceAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="sourceAwardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Source" />
         <property name="shortLabel" value="Source" />
-        <property name="maxLength" value="12" />
-        <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-        </property>
-        <property name="required" value="true" />
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    	</property>
         <property name="summary" value="Source" />
         <property name="description" value="Source" />
     </bean>
 
     <bean id="TransactionDetail-destinationAwardNumber" parent="TransactionDetail-destinationAwardNumber-parentBean" />
-    <bean id="TransactionDetail-destinationAwardNumber-parentBean" abstract="true" parent="AttributeDefinition" >
+    <bean id="TransactionDetail-destinationAwardNumber-parentBean" abstract="true" parent="KraAttributeReferenceDummy-awardNumber" >
         <property name="name" value="destinationAwardNumber" />
-        <property name="forceUppercase" value="false" />
         <property name="label" value="Destination" />
         <property name="shortLabel" value="Destination" />
-        <property name="maxLength" value="12" />
         <property name="required" value="true" />
-        <property name="control" >
-      <bean parent="TextControlDefinition" p:size="12"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="12" parent="Uif-TextControl"/>
-        </property>
-        <property name="validationPattern" >
-      <bean parent="RegexValidationPattern" p:pattern="\d\d\d\d\d\d-\d\d\d" p:validationErrorMessageKey="error.invalid.awardId"/>
-    </property>
-    <property name="validCharactersConstraint">
-      <bean parent="JavaClassPatternConstraint">
-        <property name="value" value="\d\d\d\d\d\d-\d\d\d"/>
-        <property name="messageKey" value="error.invalid.awardId"/>
-      </bean>
-    	</property>
         <property name="summary" value="Destination" />
         <property name="description" value="Destination" />
     </bean>


### PR DESCRIPTION
Fix errors in DD files for format validation:

1) validCharactersConstraint parent should be ValidCharactersConstraint and not JavaClassPatterConstraint;

2) Some validation patterns for Award Number had incorrectly specified 3 digits after the dash.
