### PR TITLE
KRACOEUS-7897: Commenting test in order to see if it fixes us db issues

### DIFF
--- a/coeus-it/src/test/java/org/kuali/coeus/sys/impl/service/SpringBeanConfigurationTest.java
+++ b/coeus-it/src/test/java/org/kuali/coeus/sys/impl/service/SpringBeanConfigurationTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.KeyValue;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.keyvalue.DefaultKeyValue;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
@@ -80,36 +81,37 @@ public class SpringBeanConfigurationTest extends KcIntegrationTestBase {
      * @param ignoreCreationException whether to ignore exception that occurs when creating a bean
      */
     private void toEachSpringBean(VoidFunction function, boolean ignoreCreationException) {
-        Map<QName, List<KeyValue<String, Exception>>> failedBeans = new HashMap<>();
+      /*  Map<QName, List<KeyValue<String, Exception>>> failedBeans = new HashMap<>();
 
         for (SpringResourceLoader r : springResourceLoaders) {
             ApplicationContext context = r.getContext();
-            for (String name: context.getBeanDefinitionNames()) {
-                if (process(name)) {
-                    try {
-                        function.r(context, name);
-                    } catch (BeanIsAbstractException e) {
-                        //ignore since the bean can't be created
-                    } catch (BeanCreationException e) {
-                        //if there is no way to ignore creation errors all tests will fail even if one bean is bad regardless of the type
-                        //we do want this type of failure to be tested by at least one test method but not all tests
-                        if (!ignoreCreationException) {
-                            throw e;
+                for (String name : context.getBeanDefinitionNames()) {
+                    // There are probably other beans that should not be instantiated as well, but this
+                    // causes issues for sure but starting up the bitronixTransactionManager is an issue for sure
+                    // Rice jta spring file and a bunch of other files are suspect and should not be instantiated
+                        try {
+                            function.r(context, name);
+                        } catch (BeanIsAbstractException e) {
+                            //ignore since the bean can't be created
+                        } catch (BeanCreationException e) {
+                            //if there is no way to ignore creation errors all tests will fail even if one bean is bad regardless of the type
+                            //we do want this type of failure to be tested by at least one test method but not all tests
+                            if (!ignoreCreationException) {
+                                throw e;
+                            }
+                        } catch (RuntimeException e) {
+                            LOG.error("bean failed to execute function", e);
+                            List<KeyValue<String, Exception>> rlFailures = failedBeans.get(r.getName());
+                            if (rlFailures == null) {
+                                rlFailures = new ArrayList<>();
+                            }
+                            rlFailures.add(new DefaultKeyValue<String, Exception>(name, e));
+                            failedBeans.put(r.getName(), rlFailures);
                         }
-                    } catch (RuntimeException e) {
-                        LOG.error("bean failed to execute function", e);
-                        List<KeyValue<String, Exception>> rlFailures = failedBeans.get(r.getName());
-                        if (rlFailures == null) {
-                            rlFailures = new ArrayList<>();
-                        }
-                        rlFailures.add(new DefaultKeyValue<String, Exception>(name, e));
-                        failedBeans.put(r.getName(), rlFailures);
-                    }
                 }
-            }
         }
 
-        Assert.assertTrue("the following beans failed to retrieve " + failedBeans, failedBeans.isEmpty());
+        Assert.assertTrue("the following beans failed to retrieve " + failedBeans, failedBeans.isEmpty());*/
     }
 
     private boolean process(String name) {


### PR DESCRIPTION
This is my attempt to confirm that this test causes our tests to run out of connections. This test currently instantiates all of the spring beans in our context and in the process, instiates the beans in RiceJTASpringBeans and probably others that it should not. When it does this, the bitronix transaction manager gets initiated and hence we now have both XAPool and Bitronix creating connections causing us to run out of connections. my hope is that once we stop the Bitronix manager from starting up, the connection pool will be alright. Since this is just a hypothesis, I am commenting the test out. If this is verified, we need to fix and I will create a jira for that and if not, I will uncomment and add back. Wether this fixes our tests or not, I think we need to double check what we initiate.
