### PR TITLE
KRACOEUS-7955:fix select on wizards

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/notification/impl/SendNotificationDialog.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/notification/impl/SendNotificationDialog.xml
@@ -102,13 +102,46 @@
             <list>
                 <bean parent="Kc-Wizard-RoleResults"
                       p:progressiveRender="@{#empty(#fp.addRecipientHelper.lineType)}"
-                      p:order="10" />
+                      p:order="10" >
+                    <property name="items">
+                        <list merge="true">
+                            <bean parent="Uif-InputField" p:propertyName="selected"
+                                  p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
+                                <property name="control">
+                                    <bean parent="Uif-CheckboxControl"/>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
                 <bean parent="Kc-Wizard-PersonnelResults"
                       p:progressiveRender="@{#fp.addRecipientHelper.lineType == '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).EMPLOYEE.code}'}"
-                      p:order="20" />
+                      p:order="20" >
+                    <property name="items">
+                        <list merge="true">
+                            <bean parent="Uif-InputField" p:propertyName="selected"
+                                  p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
+                                <property name="control">
+                                    <bean parent="Uif-CheckboxControl"/>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                    </bean>
                 <bean parent="Kc-Wizard-RolodexResults"
                       p:progressiveRender="@{#fp.addRecipientHelper.lineType == '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).NONEMPLOYEE.code}'}"
-                      p:order="30" />
+                      p:order="30" >
+                    <property name="items">
+                        <list merge="true">
+                            <bean parent="Uif-InputField" p:propertyName="selected"
+                                  p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
+                                <property name="control">
+                                    <bean parent="Uif-CheckboxControl"/>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
             </list>
         </property>
         <property name="footer">

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/wizard/impl/WizardCommon.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/wizard/impl/WizardCommon.xml
@@ -147,12 +147,6 @@
     <bean id="Kc-Wizard-PersonnelResults-parentBean" abstract="true" parent="Kc-Wizard-Results">
         <property name="items">
             <list>
-                <bean parent="Uif-InputField" p:propertyName="selected" p:cssClasses="one_required"
-                      p:label="" p:readOnly="false" p:order="10">
-                    <property name="control">
-                        <bean parent="Uif-CheckboxControl"/>
-                    </property>
-                </bean>
                 <bean parent="Uif-DataField" p:propertyName="kcPerson.fullName"
                       p:label="Full Name" p:order="20" />
                 <bean parent="Uif-DataField" p:propertyName="kcPerson.userName"
@@ -175,12 +169,6 @@
     <bean id="Kc-Wizard-RolodexResults-parentBean" abstract="true" parent="Kc-Wizard-Results">
         <property name="items">
             <list>
-                <bean parent="Uif-InputField" p:propertyName="selected"
-                      p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
-                    <property name="control">
-                        <bean parent="Uif-CheckboxControl"/>
-                    </property>
-                </bean>
                 <bean parent="Uif-DataField" p:propertyName="rolodex.fullName"
                       p:label="Full Name" p:order="20" />
                 <bean parent="Uif-MessageField"
@@ -201,12 +189,6 @@
           p:showInactiveLines="true">
         <property name="items">
             <list>
-                <bean parent="Uif-InputField" p:propertyName="selected"
-                      p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
-                    <property name="control">
-                        <bean parent="Uif-CheckboxControl"/>
-                    </property>
-                </bean>
                 <bean parent="Uif-DataField" p:propertyName="role.kimRoleType.name"
                       p:label="Role Type Name" p:order="20" />
                 <bean parent="Uif-DataField" p:propertyName="role.namespaceCode"

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAddProjectPersonnelPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAddProjectPersonnelPage.xml
@@ -81,10 +81,32 @@
 			<list>
 				<bean parent="Kc-Wizard-PersonnelResults"
                       p:progressiveRender="@{#fp.addProjectPersonnelHelper.lineType == '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).EMPLOYEE.code}'}"
-					  p:order="10" />
+					  p:order="10" >
+                    <property name="items">
+                        <list merge="true">
+                            <bean parent="Uif-InputField" p:propertyName="selected"
+                                  p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
+                                <property name="control">
+                                    <bean parent="Uif-CheckboxControl"/>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
                 <bean parent="Kc-Wizard-RolodexResults"
                       p:progressiveRender="@{#fp.addProjectPersonnelHelper.lineType == '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).NONEMPLOYEE.code}'}"
-                      p:order="20" />
+                      p:order="20" >
+                    <property name="items">
+                        <list merge="true">
+                            <bean parent="Uif-InputField" p:propertyName="selected"
+                                  p:label="" p:readOnly="false" p:order="10" p:cssClasses="one_required">
+                                <property name="control">
+                                    <bean parent="Uif-CheckboxControl"/>
+                                </property>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
 			</list>
 		</property>
 		<property name="footer">


### PR DESCRIPTION
unfortunately, since merge ordering seems to be broken https://jira.kuali.org/browse/KULRICE-13288, all selects are going to appear on the right hand side of the wizard until it gets fixed.  If we want them all to appear on the left i can do that but I will have to define the results page twice once for single select and once for mulitple select.
