### PR TITLE
KRACOEUS-7539:set multipart file max upload size to MAX_FILE_SIZE_DEFAUL...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/controller/ParameterAwareCommonsMultipartResolver.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/controller/ParameterAwareCommonsMultipartResolver.java
@@ -1,0 +1,47 @@
+package org.kuali.coeus.sys.framework.controller;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.rice.coreservice.framework.parameter.ParameterConstants;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.krad.uif.field.InputField;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+
+public class ParameterAwareCommonsMultipartResolver extends CommonsMultipartResolver implements InitializingBean {
+
+    private ParameterService parameterService;
+
+    public ParameterService getParameterService() {
+        return parameterService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+   public void afterPropertiesSet() throws Exception {
+       this.setMaxUploadSize(getMaxUploadSizeParameter());
+   }
+
+    private Long getMaxUploadSizeParameter() {
+        long maxUploadSize = 0;
+        String maxString = getParameterService().getParameterValueAsString(KRADConstants.KNS_NAMESPACE, ParameterConstants.ALL_COMPONENT,KRADConstants.MAX_UPLOAD_SIZE_PARM_NM);
+
+        String suffix = StringUtils.substring(maxString,maxString.length()-1);
+        Long multiplier = Long.parseLong(StringUtils.stripEnd(maxString, suffix));
+        if (StringUtils.equals(suffix,"K")) {
+            maxUploadSize = multiplier * 1000L;
+        } else if (StringUtils.equals(suffix,"M")) {
+            maxUploadSize = multiplier * 1000000L;
+        } else if (StringUtils.equals(suffix,"G")) {
+            maxUploadSize = multiplier * 1000000000L;
+        } else {
+            maxUploadSize = Long.parseLong(maxString);
+        }
+
+        return maxUploadSize;
+    }
+}
+
+

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml
@@ -116,8 +116,8 @@
     <bean id="kradConfigurableWebBindingInitializer"
           class="org.kuali.rice.krad.web.bind.UifConfigurableWebBindingInitializer"/>
 
-    <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-        <property name="maxUploadSize" value="500000"/>
+    <bean id="multipartResolver" class="org.kuali.coeus.sys.framework.controller.ParameterAwareCommonsMultipartResolver">
+        <property name="parameterService" ref="parameterService"/>
     </bean>
 
     <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">


### PR DESCRIPTION
...T_UPLOAD parameter value

per travis's suggestion tried to override the maxUploadSize getter.  however, there is no getter defined for maxUploadSize and the size validation logic doesn't use the getter anyway but uses the actual field value.  decided to put the logic here as opposed to a SPEL expression, do to the need to calculate a long version of the string representation of the maxuploadsize
