### PR TITLE
KRACOEUS-8029 setting activity_number length to 3 in DD per actual database field size

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/IntellectualPropertyReviewActivity.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/IntellectualPropertyReviewActivity.xml
@@ -119,7 +119,7 @@
         <property name="forceUppercase" value="false" />
         <property name="label" value="Activity Number" />
         <property name="shortLabel" value="Activity Number" />
-        <property name="maxLength" value="22" />
+        <property name="maxLength" value="3" />
         <property name="required" value="true" />
         <property name="validationPattern" >
             <bean parent="NumericValidationPattern" />


### PR DESCRIPTION
activity type was originally a number of 3 characters long, it created problems.
