### PR TITLE
[KRAFDBCK-11099] Fix to AgendaCreatedNotificationRenderer

### DIFF
--- a/src/main/java/org/kuali/kra/common/committee/notification/AgendaCreatedNotificationRenderer.java
+++ b/src/main/java/org/kuali/kra/common/committee/notification/AgendaCreatedNotificationRenderer.java
@@ -67,7 +67,7 @@ public class AgendaCreatedNotificationRenderer extends CommitteeNotificationRend
         params.put(CommitteeReplacementParameters.LAST_ACTION_DATE, scheduleAgenda.getCommitteeSchedule().getScheduledDate().toString());
         params.put(CommitteeReplacementParameters.ACTION_TAKEN, actionTaken);
         params.put(CommitteeReplacementParameters.OBJECT_INDEX, new Integer(scheduleAgenda.getAgendaNumber().intValue() - 1).toString());
-        params.put(CommitteeReplacementParameters.SCHEDULE_ID, scheduleAgenda.getCommitteeSchedule().getScheduleId());
+        params.put(CommitteeReplacementParameters.SCHEDULE_ID, "" + scheduleAgenda.getCommitteeSchedule().getId()); 
         return params;
     }    
 


### PR DESCRIPTION
#viewAgenda in MeetingActionsActionBase.java assumes that `scheduleIdFk` is the `ID` field in the `COMM_SCHEDULE` table; however, scheduleId refers to the `SCHEDULE_ID` field in the `COMM_SCHEDULE` table. These values may not (and for the most part aren't) always the same. This changes uses ID field which is intended.

fixes #KRAFDBCK-11099