### PR TITLE
KRACOEUS-8031 added unit validation to award person

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/contacts/AwardPersonCreditSplitAuditRule.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/contacts/AwardPersonCreditSplitAuditRule.java
@@ -48,7 +48,6 @@ public class AwardPersonCreditSplitAuditRule implements DocumentAuditRule {
     public static final String AWARD_PERSON_CREDIT_SPLIT_ERROR_MSG_KEY = "error.award.person.credit.split.error";
     public static final String AWARD_UNIT_CREDIT_SPLIT_LIST_ERROR_KEY = "document.awardList[0].projectPersons.awardPersonUnitCreditSplits";
     public static final String AWARD_PERSON_UNIT_CREDIT_SPLIT_ERROR_MSG_KEY = "error.award.person.unit.credit.split.error";
-    private static final String CONTACTS_AUDIT_ERRORS = "contactsCreditSplitAuditErrors";
     
     private transient Collection<InvestigatorCreditType> investigatorCreditTypes;
     private transient ParameterService parameterService;
@@ -370,8 +369,13 @@ public class AwardPersonCreditSplitAuditRule implements DocumentAuditRule {
     @SuppressWarnings("unchecked")
     protected void reportAndCreateAuditCluster() {
         if (auditErrors.size() > 0) {
-            KNSGlobalVariables.getAuditErrorMap().put(CONTACTS_AUDIT_ERRORS, new AuditCluster(Constants.CONTACTS_PANEL_NAME,
-                                                                                          auditErrors, Constants.AUDIT_ERRORS));
+        	AuditCluster existingErrors = (AuditCluster) KNSGlobalVariables.getAuditErrorMap().get(Constants.CONTACTS_AUDIT_ERROR_KEY_NAME);
+            if (existingErrors == null) {
+                KNSGlobalVariables.getAuditErrorMap().put(Constants.CONTACTS_AUDIT_ERROR_KEY_NAME, new AuditCluster(Constants.CONTACTS_PANEL_NAME,
+                                                                                              auditErrors, Constants.AUDIT_ERRORS));
+            } else {
+                existingErrors.getAuditErrorList().addAll(auditErrors);
+            }
         }
     }
 }

--- a/coeus-impl/src/main/java/org/kuali/kra/award/contacts/AwardSponsorContactAuditRule.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/contacts/AwardSponsorContactAuditRule.java
@@ -34,7 +34,6 @@ public class AwardSponsorContactAuditRule implements DocumentAuditRule {
 
     private static final String AWARD_SPONSOR_CONTACT_LIST_ERROR_KEY = "document.awardList[0].sponsorContact.auditErrors";
     private static final String ERROR_AWARD_NO_SPONSOR_CONTACTS = "error.awardSponsorContact.none";
-    private static final String CONTACTS_AUDIT_ERRORS = "contactsAuditErrors";
     private List<AuditError> auditErrors;
 
     
@@ -66,9 +65,9 @@ public class AwardSponsorContactAuditRule implements DocumentAuditRule {
     @SuppressWarnings("unchecked")
     protected void reportAndCreateAuditCluster() {
         if (auditErrors.size() > 0) {
-            AuditCluster existingErrors = (AuditCluster) KNSGlobalVariables.getAuditErrorMap().get(CONTACTS_AUDIT_ERRORS);
+            AuditCluster existingErrors = (AuditCluster) KNSGlobalVariables.getAuditErrorMap().get(Constants.CONTACTS_AUDIT_ERROR_KEY_NAME);
             if (existingErrors == null) {
-                KNSGlobalVariables.getAuditErrorMap().put(CONTACTS_AUDIT_ERRORS, new AuditCluster(Constants.CONTACTS_PANEL_NAME,
+                KNSGlobalVariables.getAuditErrorMap().put(Constants.CONTACTS_AUDIT_ERROR_KEY_NAME, new AuditCluster(Constants.CONTACTS_PANEL_NAME,
                                                                                               auditErrors, Constants.AUDIT_ERRORS));
             } else {
                 existingErrors.getAuditErrorList().addAll(auditErrors);

--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
@@ -501,6 +501,7 @@ public interface Constants {
     public static final String REPORTS_PANEL_NAME = "Reports";
     public static final String CONTACTS_PANEL_NAME = "Contacts";
     public static final String CONTACTS_PANEL_ANCHOR = "Contacts";
+    public static final String CONTACTS_AUDIT_ERROR_KEY_NAME = "contactsAuditErrors";
     public static final String TERMS_PANEL_ANCHOR = "Terms";
     public static final String TERMS_PANEL_NAME = "Terms";
     public static final String PAYMENT_AND_INVOICES_PANEL_ANCHOR = "Payments";

--- a/coeus-impl/src/main/resources/ApplicationResources.properties
+++ b/coeus-impl/src/main/resources/ApplicationResources.properties
@@ -167,6 +167,7 @@ error.awardProjectPerson.person.exists={0} is already added to the Award Project
 error.awardProjectPerson.pi.exists=Only one Principal Investigator is allowed
 error.awardProjectPerson.unit.details.required=At least one Unit is required for {0}
 error.awardProjectPerson.keyperson.role.required=A Project Role is required for Key Person - {0}.
+error.awardProjectPerson.unit.required=At least one unit must be defined for {0}.
 error.awardProjectPerson.uncertified=Award investigator {0} is not included and certified in a Funding Proposal.
 error.awardSponsorContact.none=There are no Sponsor Contacts. Please enter at least one Sponsor Contact.
 error.awardReportTermItem.notunique=A duplicate Report has already been added.


### PR DESCRIPTION
You might notice I had to fix some other contact related audit rule classes such that they consolidate their errors into one audit cluster named "contacts."  The original implementation had the possibility of seeing multiple "conctacts" sections and they couldn't be expanded (duplicate key names causing problems with the JS)
