### PR TITLE
KRACOEUS-8033

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetPeriodProjectCostController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetPeriodProjectCostController.java
@@ -19,8 +19,8 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping(value = "/proposalBudget")
 public class ProposalBudgetPeriodProjectCostController extends ProposalBudgetControllerBase {
 
-	private static final String EDIT_NONPERSONNEL_PERIOD_DIALOG_ID = "PropBudget-EditNonPersonnelPeriod-Section";
-	private static final String EDIT_NONPERSONNEL_PARTICIPANT_DIALOG_ID = "PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection";
+	private static final String EDIT_NONPERSONNEL_PERIOD_DIALOG_ID = "PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog";
+	private static final String EDIT_NONPERSONNEL_PARTICIPANT_DIALOG_ID = "PropBudget-NonPersonnelCostsPage-EditParticipantSupport-Dialog";
 	protected static final String CONFIRM_PERIOD_CHANGES_DIALOG_ID = "PropBudget-ConfirmPeriodChangesDialog";
 	
 

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
@@ -57,6 +57,16 @@
 				<bean id="PropBudget-SummaryPage" parent="PropBudget-UnderDevelopmentPage" />				
 			</list>
 		</property>
+ 		<property name="dialogs">
+            <list>
+            	<bean id="PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog" parent="PropBudget-NonPersonnelCostsPage-AddNonPersonnel"
+            		p:retrieveViaAjax="true"/>
+            	<bean id="PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog" parent="PropBudget-EditNonPersonnelPeriod-Section"
+            		p:retrieveViaAjax="true"/>
+            	<bean id="PropBudget-NonPersonnelCostsPage-EditParticipantSupport-Dialog" parent="PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection"
+            		p:retrieveViaAjax="true"/>
+            </list>
+        </property>		
 	</bean>
 
 	<bean id="PropBudget-Menu" parent="PropBudget-Menu-parentBean" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetNonPersonnelCostsPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetNonPersonnelCostsPage.xml
@@ -102,7 +102,7 @@
 
 	<bean id="PropBudget-NonPersonnelCostsPage-AssignNonPersonnel" parent="PropBudget-NonPersonnelCostsPage-AssignNonPersonnel-parentBean"/>
 	<bean id="PropBudget-NonPersonnelCostsPage-AssignNonPersonnel-parentBean" abstract="true" parent="Uif-SecondaryActionButton-Mini" 
-		p:successCallback="showDialog('PropBudget-NonPersonnelCostsPage-AddNonPersonnel');" p:actionLabel="Assign Non-Personnel..."
+		p:successCallback="showDialog('PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog');" p:actionLabel="Assign Non-Personnel..."
 		p:refreshId="PropBudget-NonPersonnelCostsPage-AddNonPersonnel"
 		p:methodToCall="assignLineItemToPeriod">
 		<property name="additionalSubmitData">
@@ -115,7 +115,7 @@
     <bean id="PropBudget-NonPersonnelCostsPage-AddNonPersonnel" parent="PropBudget-NonPersonnelCostsPage-AddNonPersonnel-parentBean"/>
     <bean id="PropBudget-NonPersonnelCostsPage-AddNonPersonnel-parentBean" abstract="true" parent="Uif-DialogGroup"
           p:fieldBindingObjectPath="addProjectBudgetLineItemHelper"
-          p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel'));});"
+          p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog'));});"
           p:header.headerText="Add Assigned Non-Personnel">
         <property name="items">
             <list>
@@ -143,7 +143,7 @@
 
 	<bean id="PropBudget-EditNonPersonnelPeriod-Section" parent="PropBudget-EditNonPersonnelPeriod-Section-parent" />
 	<bean id="PropBudget-EditNonPersonnelPeriod-Section-parent" p:fieldBindingObjectPath="addProjectBudgetLineItemHelper" abstract="true" parent="Uif-DialogGroup" 
-        p:onHideDialogScript="jQuery('#PropBudget-EditNonPersonnelPeriod-Section').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-EditNonPersonnelPeriod-Section'));});"
+        p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog'));});"
 		p:headerText="Edit Assigned Non-Personnel">
 		<property name="items">
 			<list>
@@ -286,7 +286,7 @@
 
 	<bean id="PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection" parent="PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection-parent" />
 	<bean id="PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection-parent" p:fieldBindingObjectPath="addProjectBudgetLineItemHelper" abstract="true" parent="Uif-DialogGroup" 
-        p:onHideDialogScript="jQuery('#PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-EditNonPersonnelPeriod-ParticipantSupportSection'));});"
+        p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-EditParticipantSupport-Dialog').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-EditParticipantSupport-Dialog'));});"
 		p:headerText="Participants">
 		<property name="items">
 			<list>


### PR DESCRIPTION
Fix Proposal budget non-personnel cost - dialog refresh issue
Issue - multiple dialogs in a page with refreshWhenChangedPropertyNames where refresh does not work as
expected.
As discussed with Brian, since rice is going to abandon support for on request only dialogs suggested solution is to add required dialogs into the dialogs property of view.
