### PR TITLE
KRACOEUS-8110 fixing assign to agenda IACUC authorizors

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/auth/IacucProtocolAssignToAgendaUnavailableAuthorizer.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/auth/IacucProtocolAssignToAgendaUnavailableAuthorizer.java
@@ -32,12 +32,11 @@ public class IacucProtocolAssignToAgendaUnavailableAuthorizer extends IacucProto
     @Override
     public boolean isAuthorized(String username, IacucProtocolTask task) {
         ProtocolBase protocol = task.getProtocol();
-        return !( kraWorkflowService.isInWorkflow(protocol.getProtocolDocument())
+        return !(kraWorkflowService.isInWorkflow(protocol.getProtocolDocument())
                 && kraWorkflowService.isCurrentNode(protocol.getProtocolDocument(), Constants.PROTOCOL_IACUCREVIEW_ROUTE_NODE_NAME)
-                && canExecuteAction(protocol, IacucProtocolActionType.ASSIGNED_TO_AGENDA) 
-                && !isAssignedToCommittee(protocol)
-                )
-                && hasPermission(username, protocol, PermissionConstants.PERFORM_IACUC_ACTIONS_ON_PROTO);
+                && canExecuteAction(protocol, IacucProtocolActionType.ASSIGNED_TO_AGENDA)
+                && isAssignedToCommittee(protocol)
+                && hasPermission(username, protocol, PermissionConstants.PERFORM_IACUC_ACTIONS_ON_PROTO));
     }
 
     public KcWorkflowService getKraWorkflowService() {


### PR DESCRIPTION
assign to agenda needs to be available on the intitial submission, that references the changes to the drool file.  I fixed IacucProtocolAssignToAgendaUnavailableAuthorizer to be the opposite of IacucProtocolAssignToAgendaAuthorizer.
