### PR TITLE
KRACOEUS-8125 fixing protocols so they route with add hoc approvers 

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/actions/IacucProtocolActionsAction.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/actions/IacucProtocolActionsAction.java
@@ -339,8 +339,8 @@ public class IacucProtocolActionsAction extends IacucProtocolAction {
     throws Exception {
         IacucProtocolForm protocolForm = (IacucProtocolForm) form;
         List<ProtocolReviewerBeanBase> reviewers = getReviewers(protocolForm, request, "iacucProtocolSubmitAction");
-        getProtocolActionRequestService().submitForReview(protocolForm, reviewers);
         super.route(mapping, protocolForm, request, response);
+        getProtocolActionRequestService().submitForReview(protocolForm, reviewers);
         return routeProtocolToHoldingPage(mapping, protocolForm);
     }
     

--- a/coeus-impl/src/main/java/org/kuali/kra/irb/actions/ProtocolProtocolActionsAction.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/irb/actions/ProtocolProtocolActionsAction.java
@@ -355,8 +355,8 @@ public class ProtocolProtocolActionsAction extends ProtocolAction implements Aud
     private ActionForward submitForReviewAndRedirect(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) 
         throws Exception {
         ProtocolForm protocolForm = (ProtocolForm) form;
-        boolean isPromptToNotifyUser = getProtocolActionRequestService().submitForReviewAndPromptToNotifyUser(protocolForm);
         super.route(mapping, protocolForm, request, response);
+        boolean isPromptToNotifyUser = getProtocolActionRequestService().submitForReviewAndPromptToNotifyUser(protocolForm);
         if (isPromptToNotifyUser) {
             return mapping.findForward(IrbConstants.PROTOCOL_NOTIFICATION_EDITOR);
         } else {             


### PR DESCRIPTION
KRACOEUS-8125 fixing protocols so they route when add hoc approvers are added.  Order matters, route action needs to happen before protocolsubmission service action is called.  With this change 6.0 operates how 5.2.x operates. 
