### PR TITLE
KRACOEUS-8064: Personnel can be duplicated when protocol amendment is ap...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocol.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocol.java
@@ -41,11 +41,13 @@ import org.kuali.kra.iacuc.threers.IacucAlternateSearch;
 import org.kuali.kra.iacuc.threers.IacucPrinciples;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.RoleConstants;
+import org.kuali.kra.irb.actions.amendrenew.ProtocolModule;
 import org.kuali.kra.kim.bo.KcKimAttributes;
 import org.kuali.coeus.common.framework.krms.KrmsRulesContext;
 import org.kuali.kra.protocol.ProtocolBase;
 import org.kuali.kra.protocol.actions.ProtocolActionBase;
 import org.kuali.kra.protocol.actions.ProtocolStatusBase;
+import org.kuali.kra.protocol.actions.amendrenew.ProtocolAmendRenewModuleBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionStatusBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionTypeBase;
@@ -608,8 +610,39 @@ public class IacucProtocol extends ProtocolBase {
             mergeProtocolExceptions(amendment);
         }
     }
-    
-    
+
+    protected void removeMergeableLists(List<ProtocolAmendRenewModuleBase> modules) {
+        for (ProtocolAmendRenewModuleBase module: modules) {
+            String protocolModuleTypeCode = module.getProtocolModuleTypeCode();
+            if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.AREAS_OF_RESEARCH)) {
+                this.getProtocolResearchAreas().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.FUNDING_SOURCE)) {
+                this.getProtocolFundingSources().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.PROTOCOL_ORGANIZATIONS)) {
+                this.getProtocolLocations().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.PROTOCOL_PERSONNEL)) {
+                this.getProtocolPersons().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.PROTOCOL_REFERENCES)) {
+                this.getProtocolReferences().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.THREE_RS)) {
+                this.getIacucPrinciples().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.PROCEDURES)) {
+                this.getIacucPrinciples().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, IacucProtocolModule.EXCEPTIONS)) {
+                this.getIacucPrinciples().clear();
+            }
+        }
+    }
+
+
+
     /*
      * merge amendment/renewal protocol action to original protocol when A/R is approved
      */

--- a/coeus-impl/src/main/java/org/kuali/kra/irb/Protocol.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/irb/Protocol.java
@@ -39,6 +39,7 @@ import org.kuali.kra.irb.summary.ProtocolSummary;
 import org.kuali.coeus.common.framework.krms.KrmsRulesContext;
 import org.kuali.kra.protocol.ProtocolBase;
 import org.kuali.kra.protocol.actions.ProtocolStatusBase;
+import org.kuali.kra.protocol.actions.amendrenew.ProtocolAmendRenewModuleBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionStatusBase;
 import org.kuali.kra.protocol.actions.submit.ProtocolSubmissionTypeBase;
@@ -194,6 +195,31 @@ public class Protocol extends ProtocolBase {
             mergeProtocolQuestionnaire(amendment);
         }
     }
+
+    protected void removeMergeableLists(List<ProtocolAmendRenewModuleBase> modules) {
+        for (ProtocolAmendRenewModuleBase module: modules) {
+            String protocolModuleTypeCode = module.getProtocolModuleTypeCode();
+            if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.AREAS_OF_RESEARCH)) {
+                this.getProtocolResearchAreas().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.FUNDING_SOURCE)) {
+                this.getProtocolFundingSources().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.PROTOCOL_ORGANIZATIONS)) {
+                this.getProtocolLocations().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.PROTOCOL_PERSONNEL)) {
+                this.getProtocolPersons().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.PROTOCOL_REFERENCES)) {
+                this.getProtocolReferences().clear();
+            }
+            else if (StringUtils.equals(protocolModuleTypeCode, ProtocolModule.SUBJECTS)) {
+                this.getProtocolParticipants().clear();
+            }
+        }
+    }
+
 
     /*
      * get submit for review questionnaire answerheaders

--- a/coeus-impl/src/main/java/org/kuali/kra/protocol/ProtocolBase.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/protocol/ProtocolBase.java
@@ -1083,12 +1083,14 @@ public abstract class ProtocolBase extends KcPersistableBusinessObjectBase imple
     public void merge(ProtocolBase amendment) {
         merge(amendment, true);
     }
-    
+
     // this method was modified during IRB backfit merge with the assumption that these changes are applicable to both IRB and IACUC
     public void merge(ProtocolBase amendment, boolean mergeActions) {
         // set this value here, since it is applicable regardless of which modules are amended
         this.lastApprovalDate = amendment.getLastApprovalDate();
         List<ProtocolAmendRenewModuleBase> modules = amendment.getProtocolAmendRenewal().getModules();
+        removeMergeableLists(modules);          // remove lists from copy of original protocol
+        getBusinessObjectService().save(this);  // force OJB to persist removal of lists
         for (ProtocolAmendRenewModuleBase module : modules) {
             merge(amendment, module.getProtocolModuleTypeCode());
         }
@@ -1126,6 +1128,7 @@ public abstract class ProtocolBase extends KcPersistableBusinessObjectBase imple
     
     public abstract void merge(ProtocolBase amendment, String protocolModuleTypeCode);
     
+    protected abstract void removeMergeableLists(List<ProtocolAmendRenewModuleBase> modules);
 
     protected void mergeProtocolQuestionnaire(ProtocolBase amendment) {
         // TODO : what if user did not edit questionnaire at all, then questionnaire will be wiped out ?


### PR DESCRIPTION
Apparently some collection elements are not removed when a Protocol is saved, then the collection lists are updated, then the protocol is saved again. So the fix here is to remove the collections that are going to be modified and then save the protocol object before the modified collections are added back in.

I know this is probably not the best solution but it looks like a rice issue and at this point it might be unreasonable to expect a fix before the KC 6.0 timeframe.
