### PR TITLE
KRACOEUS-8160 fixing custom data validation

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/framework/custom/AuditCustomDataEvent.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/framework/custom/AuditCustomDataEvent.java
@@ -26,9 +26,6 @@ import org.kuali.rice.krad.util.GlobalVariables;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.kuali.coeus.propdev.impl.datavalidation.ProposalDevelopmentDataValidationConstants.*;
-
-
 public class AuditCustomDataEvent extends SaveCustomDataEvent {
 
     public AuditCustomDataEvent(KcTransactionalDocumentBase document) {
@@ -36,16 +33,15 @@ public class AuditCustomDataEvent extends SaveCustomDataEvent {
     }
     
     public void reportError(CustomAttribute customAttribute, String propertyName, String errorKey, String... errorParams) {
-        String key = SUPPLEMENTAL_PAGE_NAME + "." +customAttribute.getGroupName();
-        AuditCluster auditCluster = GlobalVariables.getAuditErrorMap().get(key);
+        String key = "CustomData" + StringUtils.deleteWhitespace(customAttribute.getGroupName()) + "Errors";
+        AuditCluster auditCluster = (AuditCluster) GlobalVariables.getAuditErrorMap().get(key);
         if (auditCluster == null) {
             List<AuditError> auditErrors = new ArrayList<AuditError>();
-            auditCluster = new AuditCluster(key, auditErrors, AUDIT_ERRORS);
+            auditCluster = new AuditCluster(customAttribute.getGroupName(), auditErrors, Constants.AUDIT_ERRORS);
             GlobalVariables.getAuditErrorMap().put(key, auditCluster);
         }
         List<AuditError> auditErrors = auditCluster.getAuditErrorList();
-        auditErrors.add(new AuditError(StringUtils.removePattern(customAttribute.getGroupName() + "_" + customAttribute.getLabel(), "([^0-9a-zA-Z\\-_])"),
-                errorKey, SUPPLEMENTAL_PAGE_ID + "." + customAttribute.getGroupName().replace(" ","_"), errorParams));
+        auditErrors.add(new AuditError(propertyName, errorKey, StringUtils.deleteWhitespace(Constants.CUSTOM_ATTRIBUTES_PAGE + "." + customAttribute.getGroupName()), errorParams));
 
     }
 

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocumentRule.java
@@ -38,6 +38,7 @@ import org.kuali.coeus.propdev.impl.budget.editable.ProposalBudgetDataOverrideRu
 import org.kuali.coeus.propdev.impl.copy.CopyProposalRule;
 import org.kuali.coeus.propdev.impl.copy.ProposalCopyCriteria;
 import org.kuali.coeus.propdev.impl.copy.ProposalDevelopmentCopyRule;
+import org.kuali.coeus.propdev.impl.custom.AuditProposalCustomDataEvent;
 import org.kuali.coeus.propdev.impl.docperm.*;
 import org.kuali.coeus.propdev.impl.editable.ProposalDataOverrideEvent;
 import org.kuali.coeus.propdev.impl.editable.ProposalDataOverrideRule;
@@ -61,6 +62,7 @@ import org.kuali.coeus.propdev.impl.s2s.ProposalDevelopmentGrantsGovAuditRule;
 import org.kuali.coeus.propdev.impl.s2s.question.ProposalDevelopmentS2sQuestionnaireAuditRule;
 import org.kuali.coeus.propdev.impl.ynq.ProposalDevelopmentYnqAuditRule;
 import org.kuali.coeus.propdev.impl.ynq.ProposalYnq;
+import org.kuali.coeus.sys.framework.model.KcTransactionalDocumentBase;
 import org.kuali.coeus.sys.framework.rule.KcBusinessRule;
 import org.kuali.coeus.sys.framework.rule.KcDocumentEventBaseExtension;
 import org.kuali.coeus.sys.framework.rule.KcTransactionalDocumentRuleBase;
@@ -450,7 +452,7 @@ public class ProposalDevelopmentDocumentRule extends KcTransactionalDocumentRule
         }
         boolean retval = true;
         
-        retval &= new KcDocumentBaseAuditRule().processRunAuditBusinessRules(document);
+        retval &= new CustomDataRule().processRules(new AuditProposalCustomDataEvent((KcTransactionalDocumentBase)document));
         
         retval &= new ProposalDevelopmentProposalRequiredFieldsAuditRule().processRunAuditBusinessRules(document);
         

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/custom/AuditProposalCustomDataEvent.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/custom/AuditProposalCustomDataEvent.java
@@ -1,0 +1,38 @@
+package org.kuali.coeus.propdev.impl.custom;
+
+import static org.kuali.coeus.propdev.impl.datavalidation.ProposalDevelopmentDataValidationConstants.AUDIT_ERRORS;
+import static org.kuali.coeus.propdev.impl.datavalidation.ProposalDevelopmentDataValidationConstants.SUPPLEMENTAL_PAGE_ID;
+import static org.kuali.coeus.propdev.impl.datavalidation.ProposalDevelopmentDataValidationConstants.SUPPLEMENTAL_PAGE_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.coeus.common.framework.custom.AuditCustomDataEvent;
+import org.kuali.coeus.common.framework.custom.attr.CustomAttribute;
+import org.kuali.coeus.sys.framework.model.KcTransactionalDocumentBase;
+import org.kuali.rice.krad.util.AuditCluster;
+import org.kuali.rice.krad.util.AuditError;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+public class AuditProposalCustomDataEvent extends AuditCustomDataEvent {
+	
+	public AuditProposalCustomDataEvent(KcTransactionalDocumentBase document) {
+		super(document);
+	}
+
+	@Override
+	public void reportError(CustomAttribute customAttribute, String propertyName, String errorKey, String... errorParams) {
+        String key = SUPPLEMENTAL_PAGE_NAME + "." +customAttribute.getGroupName();
+        AuditCluster auditCluster = GlobalVariables.getAuditErrorMap().get(key);
+        if (auditCluster == null) {
+            List<AuditError> auditErrors = new ArrayList<AuditError>();
+            auditCluster = new AuditCluster(key, auditErrors, AUDIT_ERRORS);
+            GlobalVariables.getAuditErrorMap().put(key, auditCluster);
+        }
+        List<AuditError> auditErrors = auditCluster.getAuditErrorList();
+        auditErrors.add(new AuditError(StringUtils.removePattern(customAttribute.getGroupName() + "_" + customAttribute.getLabel(), "([^0-9a-zA-Z\\-_])"),
+                errorKey, SUPPLEMENTAL_PAGE_ID + "." + customAttribute.getGroupName().replace(" ","_"), errorParams));
+
+    }
+}


### PR DESCRIPTION
A recent change to custom data validation for proposal development, broke the links in the other documents.  This commit reverses those changes, and implements those same changes just PD.
