### PR TITLE
KRACOEUS-8186

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetRateAndPeriodController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetRateAndPeriodController.java
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping(value = "/proposalBudget")
 public class ProposalBudgetRateAndPeriodController extends ProposalBudgetControllerBase {
 
-	private static final String CONFIRM_PERIOD_CHANGES_DIALOG_ID = "PropBudget-ConfirmPeriodChangesDialog";
+	private static final String CONFIRM_PERIOD_CHANGES_DIALOG_ID = "PropBudget-PeriodsPage-ConfirmPeriodChangesDialog";
 
     @Autowired
     @Qualifier("budgetSummaryService")
@@ -54,20 +54,8 @@ public class ProposalBudgetRateAndPeriodController extends ProposalBudgetControl
     @RequestMapping(params="methodToCall=recalculateBudgetWithChanges")
     public ModelAndView recalculateBudgetWithChanges(@ModelAttribute("KualiForm") ProposalBudgetForm form, BindingResult result, HttpServletRequest request, HttpServletResponse response) throws Exception {
         ProposalDevelopmentBudgetExt budget = form.getBudget();
-        DialogResponse dialogResponse = form.getDialogResponse(CONFIRM_PERIOD_CHANGES_DIALOG_ID);
-        boolean confirmRecalculate = true;
-        
-    	if(dialogResponse == null) {
-    		form.setDefaultBudgetPeriodWarningMessage(getKualiConfigurationService().getPropertyValueAsString(QUESTION_RECALCULATE_BUDGET_CONFIRMATION));
-        	return getModelAndViewService().showDialog(CONFIRM_PERIOD_CHANGES_DIALOG_ID, true, form);
-    	}else {
-        	confirmRecalculate = dialogResponse.getResponseAsBoolean();
-    	}
-    	
-        if(confirmRecalculate) {
-        	getBudgetSummaryService().updateOnOffCampusFlag(budget, budget.getOnOffCampusFlag());
-        	getBudgetSummaryService().calculateBudget(budget);
-        }
+    	getBudgetSummaryService().updateOnOffCampusFlag(budget, budget.getOnOffCampusFlag());
+    	getBudgetSummaryService().calculateBudget(budget);
         return getModelAndViewService().getModelAndView(form);
     }    
 		

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetPeriodsPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetPeriodsPage.xml
@@ -118,6 +118,6 @@
         </property>
     </bean>
 	<!-- this dialog will be triggered from the controller -->
-	<bean id="PropBudget-ConfirmPeriodChangesDialog" parent="Uif-DialogGroup-YesNo" p:promptText="@{defaultBudgetPeriodWarningMessage}"/>
+	<bean id="PropBudget-PeriodsPage-ConfirmPeriodChangesDialog" parent="Uif-DialogGroup-YesNo" p:promptText="@{defaultBudgetPeriodWarningMessage}"/>
       
 </beans>


### PR DESCRIPTION
KRACOEUS-8186
Removing warning message for recalculate
Checking 5.2.x I see that the warning message is displayed when Unrecovered F & A Rate Type or F&A Rate Type is changed and in 5.2.x these are in a different panel under Parameters tab
This option is not available in Periods and Totals page.
