### PR TITLE
KRACOEUS-8260: Saving protocol results in multiple Special Reviews

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/compliance/core/SpecialReviewServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/compliance/core/SpecialReviewServiceImpl.java
@@ -180,6 +180,7 @@ public class SpecialReviewServiceImpl implements SpecialReviewService {
         } else if (StringUtils.equals(FundingSourceType.INSTITUTIONAL_PROPOSAL, fundingSourceTypeCode)) {
             InstitutionalProposal institutionalProposal = getInstitutionalProposal(fundingSourceNumber);
             if (institutionalProposal != null) {
+                institutionalProposal.refreshReferenceObject("specialReviews");
                 isLinkedToSpecialReview = isLinkedToSpecialReviews(institutionalProposal.getSpecialReviews(), protocolNumber);
             }
         }


### PR DESCRIPTION
Simple fix: When code checks to see if a Funding Source has already been added to an IP as a Special Review, the list of existing Special Reviews is not loaded. So the code thinks the Funding Source is not there and so must be added.

The fix is to refresh the list of Special Reviews before checking to see if the Funding Source has already been added.
