### PR TITLE
KRACOEUS-8254

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelController.java
@@ -52,11 +52,15 @@ public class ProposalBudgetProjectPersonnelController extends ProposalBudgetCont
 	private static final String EDIT_LINE_ITEM_DETAILS_DIALOG_ID = "PropBudget-AssignPersonnelToPeriodsPage-DetailsAndRates";
 	private static final String CONFIRM_PERSONNEL_PERIOD_CHANGES_DIALOG_ID = "PropBudget-ConfirmPeriodChangesDialog";
 	private static final String ADD_PERSONNEL_PERIOD_DIALOG_ID = "PropBudget-AssignPersonnelToPeriodsPage-AddPersonnel";
+	private static final String ADD_PROJECT_PERSONNEL_DIALOG_ID = "PropBudget-ProjectPersonnelPage-Wizard";
+	
 	
 	@RequestMapping(params="methodToCall=searchProjectPersonnel")
 	public ModelAndView searchProjectPersonnel(@ModelAttribute("KualiForm") ProposalBudgetForm form) throws Exception {
-       form.getAddProjectPersonnelHelper().getResults().clear();
-       form.getAddProjectPersonnelHelper().setResults(getWizardControllerService().performWizardSearch(form.getAddProjectPersonnelHelper().getLookupFieldValues(),form.getAddProjectPersonnelHelper().getLineType()));
+		if(!StringUtils.isEmpty(form.getAddProjectPersonnelHelper().getLineType())) {
+		       form.getAddProjectPersonnelHelper().getResults().clear();
+		       form.getAddProjectPersonnelHelper().setResults(getWizardControllerService().performWizardSearch(form.getAddProjectPersonnelHelper().getLookupFieldValues(),form.getAddProjectPersonnelHelper().getLineType()));
+		}
        return getModelAndViewService().getModelAndView(form);
 	}
 
@@ -104,6 +108,12 @@ public class ProposalBudgetProjectPersonnelController extends ProposalBudgetCont
     	return getModelAndViewService().showDialog(EDIT_PROJECT_PERSONNEL_DIALOG_ID, true, form);
 	}
 
+	@RequestMapping(params="methodToCall=prepareAddProjectPersonnel")
+	public ModelAndView prepareAddProjectPersonnel(@ModelAttribute("KualiForm") ProposalBudgetForm form) throws Exception {
+        form.getAddProjectPersonnelHelper().setLineType(PersonTypeConstants.EMPLOYEE.getCode());
+        return getModelAndViewService().showDialog(ADD_PROJECT_PERSONNEL_DIALOG_ID,true,form);
+	}
+	
 	@RequestMapping(params="methodToCall=updatePersonDetails")
 	public ModelAndView updatePersonDetails(@ModelAttribute("KualiForm") ProposalBudgetForm form) throws Exception {
 	    int selectedLine = Integer.parseInt(form.getAddProjectPersonnelHelper().getEditLineIndex());

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetCommon.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetCommon.xml
@@ -13,7 +13,7 @@
                     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
              
 	<bean id="PropBudget-Page" parent="PropBudget-Page-parentBean"/>
-	<bean id="PropBudget-Page-parentBean" abstract="true" parent="Uif-Page">
+	<bean id="PropBudget-Page-parentBean" abstract="true" parent="Uif-Page" p:enterKeyAction="@DEFAULT">
 		<property name="footer">
 			<bean parent="PropBudget-Footer" p:order="10"/>
 		</property>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetNonPersonnelCostsPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetNonPersonnelCostsPage.xml
@@ -128,7 +128,7 @@
     <bean id="PropBudget-NonPersonnelCostsPage-AddNonPersonnel-parentBean" abstract="true" parent="Uif-DialogGroup"
           p:fieldBindingObjectPath="addProjectBudgetLineItemHelper"
           p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-AddNonPersonnel-Dialog'));});"
-          p:header.headerText="Add Assigned Non-Personnel">
+          p:header.headerText="Add Assigned Non-Personnel" p:enterKeyAction="@DEFAULT">
         <property name="items">
             <list>
 				<ref bean="PropBudget-NonPersonnelCosts-LineItem-ObjectFieldSection" />
@@ -140,7 +140,7 @@
                     <list>
                         <bean parent="Uif-PrimaryActionButton" p:actionLabel="Add Non-Personnel Item to @{#fp.addProjectBudgetLineItemHelper.currentTabBudgetPeriod.budgetPeriod}" p:methodToCall="addLineItemToPeriod"
                               p:refreshId="PropBudget-NonPersonnelCosts-LineItemDetails_@{#fp.addProjectBudgetLineItemHelper.currentTabBudgetPeriod.budgetPeriod}"
-                              p:dialogDismissOption="REQUEST"
+                              p:dialogDismissOption="REQUEST" p:defaultEnterKeyAction="true"
                               p:order="10" p:performClientSideValidation="true"/>
                         <bean parent="Uif-DialogDismissButton" p:actionLabel="Cancel" p:order="20"/>
                     </list>
@@ -156,7 +156,7 @@
 	<bean id="PropBudget-EditNonPersonnelPeriod-Section" parent="PropBudget-EditNonPersonnelPeriod-Section-parent" />
 	<bean id="PropBudget-EditNonPersonnelPeriod-Section-parent" p:fieldBindingObjectPath="addProjectBudgetLineItemHelper" abstract="true" parent="Uif-DialogGroup" 
         p:onHideDialogScript="jQuery('#PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog').one(kradVariables.EVENTS.HIDDEN_MODAL, function(e){Kc.Dialog.resetDialogFields(jQuery('#PropBudget-NonPersonnelCostsPage-EditNonPersonnel-Dialog'));});"
-		p:headerText="Edit Assigned Non-Personnel">
+		p:headerText="Edit Assigned Non-Personnel" p:enterKeyAction="@DEFAULT">
 		<property name="items">
 			<list>
 				<bean parent="Uif-DataField" p:fieldLabel.labelText=" " p:propertyName="budgetLineItem.lineItemDescription"
@@ -173,7 +173,7 @@
                       		p:actionParameters="@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_PATH}:budget.budgetLineItems,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_ID}:PropBudget-NonPersonnelCosts-LineItemDetails,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_LINE_INDEX}:@{addProjectBudgetLineItemHelper.editLineIndex}"
-							p:dialogDismissOption="REQUEST" p:performClientSideValidation="true"
+							p:dialogDismissOption="REQUEST" p:performClientSideValidation="true" p:defaultEnterKeyAction="true"
 							p:order="10" p:render="@{!#parent.readOnly}"/>
 						<bean parent="Uif-SecondaryActionButton-Mini" p:actionLabel="Save And Apply To Other Periods"
                       		p:actionParameters="@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_PATH}:budget.budgetLineItems,

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAddProjectPersonnelPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAddProjectPersonnelPage.xml
@@ -18,11 +18,10 @@
 	<bean id="PropBudget-ProjectPersonnelPage-AddButton" parent="PropBudget-ProjectPersonnelPage-AddButton-parentBean" />
 	<bean id="PropBudget-ProjectPersonnelPage-AddButton-parentBean" abstract="true"
 		parent="Uif-SecondaryActionButton-Mini" p:actionLabel="Add Personnel" p:render="@{!#parent.readOnly}"
-		p:refreshId="PropBudget-ProjectPersonnelPage-Wizard" p:methodToCall="refresh"
-		p:successCallback="showDialog('PropBudget-ProjectPersonnelPage-Wizard');"
+		p:methodToCall="prepareAddProjectPersonnel"
 		p:actionParameters="PropBudget-ProjectPersonnelPage-Wizard.step:0" p:iconClass="icon-plus" />
 
-    <bean id="PropBudget-ProjectPersonnelPage-Wizard" parent="Kc-Wizard"
+    <bean id="PropBudget-ProjectPersonnelPage-Wizard" parent="Kc-Wizard" p:enterKeyAction="@DEFAULT"
           p:fieldBindingObjectPath="addProjectPersonnelHelper">
         <property name="items">
             <list>
@@ -40,7 +39,7 @@
 	<bean id="PropBudget-ProjectPersonnelPage-WizardButton-Continue" parent="PropBudget-ProjectPersonnelPage-WizardButton-Continue-parentBean" />
 	<bean id="PropBudget-ProjectPersonnelPage-WizardButton-Continue-parentBean"
 		abstract="true" parent="PropBudget-ProjectPersonnelPage-WizardButton"
-		p:actionLabel="Search"/>
+		p:actionLabel="Search" p:defaultEnterKeyAction="true" />
 
 	<bean id="PropBudget-ProjectPersonnelPage-WizardButton-Back" parent="PropBudget-ProjectPersonnelPage-WizardButton-Back-parentBean" />
 	<bean id="PropBudget-ProjectPersonnelPage-WizardButton-Back-parentBean"
@@ -60,11 +59,11 @@
 			</list>
 		</property>
 		<property name="footer">
-			<bean parent="Uif-DialogFooter">
+			<bean parent="Uif-DialogFooter" p:progressiveRender="@{#fp.addProjectPersonnelHelper.lineType != '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).TBN.code}'}">
 				<property name="items">
 					<list>
 						<bean parent="PropBudget-ProjectPersonnelPage-WizardButton-Continue"
-							p:progressiveRender="@{#fp.addProjectPersonnelHelper.lineType != 'T'}"
+							p:performClientSideValidation="true"
 							p:methodToCall="searchProjectPersonnel" p:actionParameters="PropBudget-ProjectPersonnelPage-Wizard.step:1"
                             p:successCallback="Kc.Wizard.returnToFirstResultsPage();" p:order="10" />
                         <bean parent="Uif-SecondaryActionButton" p:actionLabel="Cancel" p:libraryCssClasses="btn,btn-link"
@@ -147,7 +146,8 @@
     <bean id="PropBudget-ProjectPersonnelPage-TypeSelection" parent="Uif-CssGridSection-1FieldLabelColumn">
         <property name="items">
             <list>
-                <bean parent="PropDev-Personnel-TypeSelection-InputField" p:optionsFinder="#{#getService('personTypeValuesFinder')}" />
+                <bean parent="PropDev-Personnel-TypeSelection-InputField" p:optionsFinder="#{#getService('personTypeValuesFinder')}" 
+                p:optionsFinder.addBlankOption="false" p:required="true"/>
             </list>
         </property>
     </bean>
@@ -164,7 +164,7 @@
 		p:collectionObjectClass="org.kuali.coeus.common.budget.framework.personnel.TbnPerson"
 		p:layoutManager.renderSequenceField="false" p:renderLineActions="false"
 		p:renderAddLine="false"
-		p:progressiveRenderAndRefresh="true"
+		p:progressiveRenderAndRefresh="true" 
 		p:progressiveRender="@{addProjectPersonnelHelper.lineType == '#{T(org.kuali.coeus.common.framework.person.PersonTypeConstants).TBN.code}'}">
 		<property name="layoutManager.richTable.templateOptions">
 			<map>
@@ -197,10 +197,11 @@
 			<bean parent="Uif-DialogFooter">
 				<property name="items">
 					<list>
-						<bean parent="Uif-PrimaryActionButton" p:actionLabel="Add TBN Personnel to Budget" 
+						<bean parent="PropBudget-ProjectPersonnelPage-WizardButton-Continue"
+							p:actionLabel="Add TBN Personnel to Budget"
 							p:refreshId="PropBudget-ProjectPersonnelPage-CollectionGroup"
 							p:successCallback="dismissDialog('PropBudget-ProjectPersonnelPage-Wizard');"
-							p:methodToCall="addProjectPersonnel"/>
+							p:order="10" p:methodToCall="addProjectPersonnel"/>
                         <bean parent="Uif-SecondaryActionButton" p:actionLabel="Cancel" p:libraryCssClasses="btn,btn-link"
                             p:dialogDismissOption="IMMEDIATE" p:dialogResponse="false" p:order="20"/>
 					</list>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAssignPersonnelToPeriodsPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetAssignPersonnelToPeriodsPage.xml
@@ -145,7 +145,7 @@
     <bean id="PropBudget-AssignPersonnelToPeriodsPage-AddPersonnel" parent="PropBudget-AssignPersonnelToPeriodsPage-AddPersonnel-parentBean"/>
     <bean id="PropBudget-AssignPersonnelToPeriodsPage-AddPersonnel-parentBean" abstract="true" parent="Uif-DialogGroup"
           p:fieldBindingObjectPath="addProjectPersonnelHelper"
-          p:destroyDialogOnHidden="true"
+          p:destroyDialogOnHidden="true" p:enterKeyAction="@DEFAULT"
           p:header.headerText="Add Personnel to Period">
         <property name="items">
             <list>
@@ -199,6 +199,7 @@
                         <bean parent="Uif-PrimaryActionButton" p:actionLabel="Assign to Period @{#fp.addProjectPersonnelHelper.currentTabBudgetPeriod.budgetPeriod}" p:methodToCall="addPersonnelToPeriod"
                               p:refreshId="PropBudget-AssignPersonnelToPeriodsPage-PersonnelDetails_@{#fp.addProjectPersonnelHelper.currentTabBudgetPeriod.budgetPeriod}"
                               p:successCallback="dismissDialog('PropBudget-AssignPersonnelToPeriodsPage-AddPersonnel')"
+                              p:defaultEnterKeyAction="true"
                               p:order="10" p:performClientSideValidation="true"/>
                         <bean parent="Uif-DialogDismissButton" p:actionLabel="Cancel" p:order="20"/>
                     </list>
@@ -209,7 +210,7 @@
 
 	<bean id="PropBudget-EditPersonnelPeriod-Section" parent="PropBudget-EditPersonnelPeriod-Section-parent" />
 	<bean id="PropBudget-EditPersonnelPeriod-Section-parent" p:fieldBindingObjectPath="addProjectPersonnelHelper.budgetPersonnelDetail" abstract="true" parent="Uif-DialogGroup" 
-		p:headerText="Edit Assigned Personnel" p:destroyDialogOnHidden="true">
+		p:headerText="Edit Assigned Personnel" p:destroyDialogOnHidden="true" p:enterKeyAction="@DEFAULT">
 		<property name="items">
 			<list>
 				<bean parent="Uif-DataField" p:fieldLabel.labelText=" " p:propertyName="budgetPerson.personName"
@@ -226,7 +227,7 @@
                       		p:actionParameters="@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_PATH}:budget.budgetPersonnelDetails,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_ID}:PropBudget-AssignPersonnelToPeriodsPage-PersonnelDetails,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_LINE_INDEX}:@{addProjectPersonnelHelper.editLineIndex}"
-							p:dialogDismissOption="REQUEST" p:performClientSideValidation="true"
+							p:dialogDismissOption="REQUEST" p:performClientSideValidation="true" p:defaultEnterKeyAction="true"
 							p:render="@{!#parent.readOnly}" p:order="10" />
 						<bean parent="Uif-SecondaryActionButton" p:actionLabel="Calculate" p:methodToCall="calculatePersonSalaryDetails"
 							p:render="@{!#parent.readOnly}" p:dialogDismissOption="REQUEST" p:order="20" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelPage.xml
@@ -94,7 +94,7 @@
 	
 	<bean id="PropBudget-EditPersonnel-Section" parent="PropBudget-EditPersonnel-Section-parentBean" />
 	<bean id="PropBudget-EditPersonnel-Section-parentBean" p:fieldBindingObjectPath="addProjectPersonnelHelper.editBudgetPerson"
-		abstract="true" parent="Uif-DialogGroup" p:headerText="Edit Personnel" p:destroyDialogOnHidden="true">
+		abstract="true" parent="Uif-DialogGroup" p:headerText="Edit Personnel" p:enterKeyAction="@DEFAULT" p:destroyDialogOnHidden="true">
 		<property name="items">
 			<list>
 				<bean parent="Uif-DataField" p:fieldLabel.labelText=" " p:propertyName="personName"/>
@@ -120,7 +120,7 @@
                       		p:actionParameters="@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_PATH}:budget.budgetPersons,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_COLLECTION_ID}:PropBudget-ProjectPersonnelPage-CollectionGroup,
                       		@{T(org.kuali.rice.krad.uif.UifParameters).SELECTED_LINE_INDEX}:@{addProjectPersonnelHelper.editLineIndex}"
-							p:dialogDismissOption="REQUEST"
+							p:dialogDismissOption="REQUEST" p:defaultEnterKeyAction="true"
 							p:order="10" p:render="@{!#parent.readOnly}" p:performClientSideValidation="true"/>
 						<bean parent="Uif-SecondaryActionButton-Mini" p:actionLabel="Cancel"
 							p:dialogDismissOption="IMMEDIATE"


### PR DESCRIPTION
KRACOEUS-8254
Add Personnel - problem with modal behavior for Employee/Non-Employee

Looking to fix "This page is asking you to confirm that you want to leave - data you have entered may not be saved" when user hit ENTER key (issue in budget personnel -Add personnel modal), I see that this is a global issue in budget.
Default action "Return to proposal" is executed (may be first action button in sequence to perform default enter key action?) when user hit ENTER key in any budget page.
Restricting this to designated page/group
