### PR TITLE
KRACOEUS-8335: Correspondence generated during Return for SMR is on wron...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/irb/actions/IrbProtocolActionRequestServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/irb/actions/IrbProtocolActionRequestServiceImpl.java
@@ -900,8 +900,8 @@ public class IrbProtocolActionRequestServiceImpl extends ProtocolActionRequestSe
         Protocol protocol = document.getProtocol();
         ProtocolGenericActionBean actionBean = (ProtocolGenericActionBean) protocolForm.getActionHelper().getProtocolSMRBean();
         ProtocolDocument newDocument = (ProtocolDocument) getProtocolGenericActionService().returnForSMR(protocol, actionBean);
-        generateActionCorrespondence(ProtocolActionType.SPECIFIC_MINOR_REVISIONS_REQUIRED, protocolForm.getProtocolDocument().getProtocol());
         saveReviewComments(protocolForm, actionBean.getReviewCommentsBean());
+        generateActionCorrespondence(ProtocolActionType.SPECIFIC_MINOR_REVISIONS_REQUIRED, newDocument.getProtocol());
         refreshAfterProtocolAction(protocolForm, newDocument.getDocumentNumber(), ACTION_NAME_SMR, false);
         protocolForm.getActionHelper().setProtocolCorrespondence(getProtocolCorrespondence(protocolForm, IrbConstants.PROTOCOL_TAB, new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(),ProtocolActionType.SPECIFIC_MINOR_REVISIONS_REQUIRED, "Specific Minor Revisions Required"), false));
         ProtocolNotificationRequestBean notificationBean = new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(),ProtocolActionType.SPECIFIC_MINOR_REVISIONS_REQUIRED, "Specific Minor Revisions Required");
@@ -914,8 +914,8 @@ public class IrbProtocolActionRequestServiceImpl extends ProtocolActionRequestSe
         Protocol protocol = document.getProtocol();
         ProtocolGenericActionBean actionBean = (ProtocolGenericActionBean) protocolForm.getActionHelper().getProtocolSRRBean();
         ProtocolDocument newDocument = (ProtocolDocument) getProtocolGenericActionService().returnForSRR(protocol, actionBean);
-        generateActionCorrespondence(ProtocolActionType.SUBSTANTIVE_REVISIONS_REQUIRED, protocolForm.getProtocolDocument().getProtocol());
         saveReviewComments(protocolForm, actionBean.getReviewCommentsBean());
+        generateActionCorrespondence(ProtocolActionType.SUBSTANTIVE_REVISIONS_REQUIRED, newDocument.getProtocol());
         refreshAfterProtocolAction(protocolForm, newDocument.getDocumentNumber(), ACTION_NAME_SRR, false);
         protocolForm.getActionHelper().setProtocolCorrespondence(getProtocolCorrespondence(protocolForm, IrbConstants.PROTOCOL_TAB, new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(),ProtocolActionType.SUBSTANTIVE_REVISIONS_REQUIRED, "Substantive Revisions Required"), false));
         ProtocolNotificationRequestBean notificationBean = new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(),ProtocolActionType.SUBSTANTIVE_REVISIONS_REQUIRED, "Substantive Revisions Required");
@@ -928,8 +928,8 @@ public class IrbProtocolActionRequestServiceImpl extends ProtocolActionRequestSe
         Protocol protocol = document.getProtocol();
         ProtocolGenericActionBean actionBean = (ProtocolGenericActionBean) protocolForm.getActionHelper().getProtocolReturnToPIBean();
         ProtocolDocument newDocument = (ProtocolDocument) getProtocolGenericActionService().returnToPI(protocol, actionBean);
-        generateActionCorrespondence(ProtocolActionType.RETURNED_TO_PI, protocolForm.getProtocolDocument().getProtocol());
         saveReviewComments(protocolForm, actionBean.getReviewCommentsBean());
+        generateActionCorrespondence(ProtocolActionType.RETURNED_TO_PI, newDocument.getProtocol());
         refreshAfterProtocolAction(protocolForm, newDocument.getDocumentNumber(), ACTION_NAME_RETURN_TO_PI, false);
         protocolForm.getActionHelper().setProtocolCorrespondence(getProtocolCorrespondence(protocolForm, IrbConstants.PROTOCOL_TAB, new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(), ProtocolActionType.RETURNED_TO_PI, "Return To PI"), false));
         ProtocolNotificationRequestBean notificationBean = new ProtocolNotificationRequestBean(protocolForm.getProtocolDocument().getProtocol(),ProtocolActionType.RETURNED_TO_PI, "Returned To PI");


### PR DESCRIPTION
- Reversed order of saving of comments, and generation of correspondence. This prevents the loss of comments that might be used in the generation of the correspondence.
- I also used the newly created protocol in the generation of the correspondence, instead of the protocol passed in on the form (the old, now-canceled protocol).
