### PR TITLE
KRACOEUS-8345 added getParentBudget to allow searching

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/budget/document/AwardBudgetDocument.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/budget/document/AwardBudgetDocument.java
@@ -37,6 +37,7 @@ import org.kuali.kra.award.commitments.FandaRateType;
 import org.kuali.kra.award.home.Award;
 import org.kuali.kra.bo.DocumentNextvalue;
 import org.kuali.coeus.common.budget.framework.core.Budget;
+import org.kuali.coeus.common.budget.framework.core.BudgetParentDocument;
 import org.kuali.coeus.common.budget.framework.nonpersonnel.BudgetLineItem;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.RoleConstants;
@@ -401,4 +402,8 @@ public class AwardBudgetDocument extends KcTransactionalDocumentBase implements 
     public List<? extends DocumentCustomData> getDocumentCustomData() {
         return new ArrayList();
     }	
+    
+    public BudgetParentDocument getParentDocument() {
+    	return this.getBudget().getBudgetParent().getDocument();
+    }
 }


### PR DESCRIPTION
Until PD's can create valid IPs that can fund an award, this isn't fully testable. However, this prevents a stack trace from popping up if you click the search icon next to an award budget period line.
