### PR TITLE
KRACOEUS-8382:removing pessimistic lock message on submit

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentSubmitController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentSubmitController.java
@@ -51,6 +51,7 @@ import org.kuali.rice.kew.api.action.WorkflowDocumentActionsService;
 import org.kuali.rice.kew.api.document.DocumentDetail;
 import org.kuali.rice.kim.api.group.GroupService;
 import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.document.authorization.PessimisticLock;
 import org.kuali.rice.krad.service.KualiRuleService;
 import org.kuali.rice.krad.service.LegacyDataAdapter;
 import org.kuali.rice.krad.uif.UifConstants;
@@ -200,7 +201,12 @@ public class ProposalDevelopmentSubmitController extends
                     form.getWorkflowDocument().setDoNotReceiveFutureRequests();
                 }
             }
-            return getTransactionalDocumentControllerService().route(form);
+            getTransactionalDocumentControllerService().route(form);
+            for (PessimisticLock lock : form.getProposalDevelopmentDocument().getPessimisticLocks()){
+                getDataObjectService().delete(lock);
+            }
+            form.getProposalDevelopmentDocument().refreshPessimisticLocks();
+            return getModelAndViewService().getModelAndView(form);
     }
 
 


### PR DESCRIPTION
in TransactionalDocumentControllerService route method once the document is returned it calls releasePessimisticLocks(form) to clear all locks.  however, this method only clears locks for the current logged in user, and a during the route process a lock is created for KR.  this lock can't be removed by the releasePessimistcLocks nor PessimisticLockService's delete method.  So in the submit controller i use dataObjectServices to clear any remaining locks after route and refresh the locks on the document before returning the view.   
