### PR TITLE
KRACOEUS-8234:update proposal status and progress bar on routing changes

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentHomeController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/basic/ProposalDevelopmentHomeController.java
@@ -26,16 +26,15 @@ import org.kuali.coeus.common.framework.sponsor.Sponsor;
 import org.kuali.coeus.common.framework.compliance.core.SaveDocumentSpecialReviewEvent;
 import org.kuali.coeus.propdev.impl.copy.ProposalCopyCriteria;
 import org.kuali.coeus.propdev.impl.copy.ProposalCopyService;
-import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentControllerBase;
-import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocument;
-import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocumentForm;
+import org.kuali.coeus.propdev.impl.core.*;
 import org.kuali.coeus.propdev.impl.person.ProposalPerson;
+import org.kuali.coeus.propdev.impl.state.ProposalState;
+import org.kuali.coeus.propdev.impl.state.ProposalStateConstants;
 import org.kuali.coeus.sys.framework.gv.GlobalVariableService;
 import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kew.api.doctype.DocumentType;
 import org.kuali.rice.kew.api.doctype.DocumentTypeService;
-import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentViewHelperServiceImpl;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.exception.DocumentAuthorizationException;
 import org.kuali.rice.krad.service.DataDictionaryService;
@@ -105,6 +104,8 @@ public class ProposalDevelopmentHomeController extends ProposalDevelopmentContro
        getDataObjectService().wrap(form.getDevelopmentProposal()).fetchRelationship("proposalType");
        //setting to null so the previous page id(PropDev-InitiatePage) doesn't override the default
        form.setPageId(null);
+       form.getDevelopmentProposal().setProposalStateTypeCode(ProposalState.IN_PROGRESS);
+       getDataObjectService().wrap(form.getDevelopmentProposal()).fetchRelationship("proposalState");
        return getModelAndViewService().getModelAndViewWithInit(form, PROPDEV_DEFAULT_VIEW_ID);
    }
 
@@ -319,7 +320,7 @@ public class ProposalDevelopmentHomeController extends ProposalDevelopmentContro
 
             if (propDevForm.getDocument().getDocumentHeader().getWorkflowDocument().isEnroute()) {
                ((ProposalDevelopmentViewHelperServiceImpl) form.getViewHelperService()).prepareSummaryPage(propDevForm);
-               propDevForm.getView().setEntryPageId("PropDev-SubmitPage");
+               propDevForm.getView().setEntryPageId(ProposalDevelopmentConstants.KradConstants.SUBMIT_PAGE);
             }
 
             if (StringUtils.equals(form.getRequest().getParameter("viewDocument"),"true")) {

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentConstants.java
@@ -5,6 +5,7 @@ public class ProposalDevelopmentConstants {
 	public static class KradConstants {
         public static final String REJECT_DIALOG = "PropDev-SubmitPage-RejectDialog";
 		public static final String BUDGET_PAGE = "PropDev-BudgetPage";
+        public static final String SUBMIT_PAGE = "PropDev-SubmitPage";
 		public static final String PREVIOUS_PAGE_ARG = "previous";
 		public static final String NEXT_PAGE_ARG = "next";
 

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentSubmitController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentSubmitController.java
@@ -206,7 +206,8 @@ public class ProposalDevelopmentSubmitController extends
                 getDataObjectService().delete(lock);
             }
             form.getProposalDevelopmentDocument().refreshPessimisticLocks();
-            return getModelAndViewService().getModelAndView(form);
+
+        return updateProposalState(form);
     }
 
 
@@ -558,7 +559,8 @@ public class ProposalDevelopmentSubmitController extends
                 && getKcWorkflowService().isFinalApproval(workflowDoc)) {
             return submitToSponsor(form);
         }
-        return getModelAndViewService().getModelAndView(form);
+
+        return updateProposalState(form);
     }
 
     private boolean canGenerateRequestsInFuture(WorkflowDocument workflowDoc, String principalId) throws Exception {
@@ -627,6 +629,18 @@ public class ProposalDevelopmentSubmitController extends
         }
 
         return false;
+    }
+
+    protected ModelAndView updateProposalState(ProposalDevelopmentDocumentForm form) throws Exception{
+    if (getKcWorkflowService().isFinalApproval(form.getWorkflowDocument())) {
+        form.getDevelopmentProposal().setProposalStateTypeCode(ProposalState.APPROVAL_GRANTED);
+        getGlobalVariableService().getMessageMap().getInfoMessages().clear();
+        getGlobalVariableService().getMessageMap().putInfoForSectionId(ProposalDevelopmentConstants.KradConstants.SUBMIT_PAGE, KeyConstants.APPROVAL_CYCLE_COMPLETE);
+    } else {
+        form.getDevelopmentProposal().setProposalStateTypeCode(getProposalStateService().getProposalStateTypeCode(form.getProposalDevelopmentDocument(), true, false));
+    }
+    getDataObjectService().wrap(form.getDevelopmentProposal()).fetchRelationship("proposalState");
+    return getModelAndViewService().getModelAndView(form);
     }
 
     @RequestMapping(value = "/proposalDevelopment", params="methodToCall=reject")

--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
@@ -133,6 +133,7 @@ public final class KeyConstants {
     public static final String ERROR_INVESTIGATOR_CREDIT_TYPE_EXISTS = "error.investigator.credit.type.exists";
 
     public static final String INFO_PERSONNEL_INVALID_ROLE = "info.personnel.invalid.role";
+    public static final String APPROVAL_CYCLE_COMPLETE = "info.proposal.approval.final";
 
     // proposal ynq errors
     public static final String ERROR_REQUIRED_FOR_EXPLANATION = "error.required.for.explanation";

--- a/coeus-impl/src/main/resources/ApplicationResources.properties
+++ b/coeus-impl/src/main/resources/ApplicationResources.properties
@@ -1104,3 +1104,4 @@ error.unique.person.role.entry=Non unique combination of Proposal Person Role Id
 error.s2s.fileType.invalid=The uploaded file < {0} > is not a file type of < {1} >. Only files of this type should be uploaded if this proposal is being submitted via Grants.gov.
 
 info.personnel.invalid.role=The current Sponsor Code "{0}" has invalidated {1}'s current role.  {1}'s role will be defaulted to Co-Investigator.
+info.proposal.approval.final=Document was successfully approved, and has completed its approval cycle.


### PR DESCRIPTION
updates proposal status on create, submit, and approve actions.

On the final approve action there is a few seconds lag from when the approval is submitted to when the workflow document indicates that it is in the final status.  I added a loop that reloads the document every second for 15 second to check for a final status before rendering the view so the status bar and proposal status description are updated correctly. I don't know if this is a good idea and would like some feed back, any suggestions on how to better accomplish this are welcome.
