### PR TITLE
KRACOEUS-8110: Fix IACUC Assign To Agenda Unavailable authorizer

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/auth/IacucProtocolAssignToAgendaUnavailableAuthorizer.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/auth/IacucProtocolAssignToAgendaUnavailableAuthorizer.java
@@ -35,7 +35,7 @@ public class IacucProtocolAssignToAgendaUnavailableAuthorizer extends IacucProto
         return !( kraWorkflowService.isInWorkflow(protocol.getProtocolDocument())
                 && kraWorkflowService.isCurrentNode(protocol.getProtocolDocument(), Constants.PROTOCOL_IACUCREVIEW_ROUTE_NODE_NAME)
                 && canExecuteAction(protocol, IacucProtocolActionType.ASSIGNED_TO_AGENDA) 
-                && !isAssignedToCommittee(protocol)
+                && isAssignedToCommittee(protocol)
                 )
                 && hasPermission(username, protocol, PermissionConstants.PERFORM_IACUC_ACTIONS_ON_PROTO);
     }


### PR DESCRIPTION
Fixing issue where "Assign To Agenda" action appears in both the available and unavailable actions in IACUC.
