### PR TITLE
KRACOEUS-8443: avoiding the creation of datasources & pools per spring c...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/service/ConfigContextConfigObjectFactoryBean.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/service/ConfigContextConfigObjectFactoryBean.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.coeus.sys.framework.service;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.config.ConfigurationException;
+import org.kuali.rice.core.api.config.property.ConfigContext;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * Exports services in the {@link org.kuali.rice.core.api.config.property.ConfigContext#getCurrentContextConfig()} as beans available to Spring.
+ *
+ * @author Kuali Rice Team (rice.collab@kuali.org)
+ */
+public class ConfigContextConfigObjectFactoryBean implements FactoryBean<Object>, InitializingBean {
+
+	private String objectName;
+	private boolean singleton;
+	private boolean mustExist;
+
+	public ConfigContextConfigObjectFactoryBean() {
+		this.mustExist = true;
+	}
+
+	public Object getObject() throws Exception {
+		Object o =  ConfigContext.getCurrentContextConfig().getObject(this.getObjectName());
+
+		if (mustExist && o == null) {
+			throw new IllegalStateException("Service must exist and no service could be located with name='" + this.getObjectName() + "'");
+		}
+
+		return o;
+	}
+
+    public Class<?> getObjectType() {
+        if (getObjectName() == null) {
+            return null;
+        } else {
+            try {
+                // getObject throws java.lang.Exception
+                return getObject().getClass();
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
+
+	public boolean isSingleton() {
+		return singleton;
+	}
+
+    public String getObjectName() {
+		return objectName;
+	}
+
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+
+	public void setSingleton(boolean singleton) {
+		this.singleton = singleton;
+	}
+
+	public boolean isMustExist() {
+		return mustExist;
+	}
+
+	public void setMustExist(boolean mustExist) {
+		this.mustExist = mustExist;
+	}
+
+	public void afterPropertiesSet() throws Exception {
+		if (StringUtils.isBlank(this.getObjectName())) {
+			throw new ConfigurationException("No objectName given.");
+		}
+	}
+
+}

--- a/coeus-impl/src/main/resources/META-INF/kc-config-defaults.xml
+++ b/coeus-impl/src/main/resources/META-INF/kc-config-defaults.xml
@@ -100,10 +100,10 @@
 	<param name="datasource.url">jdbc:oracle:thin:@127.0.0.1:1521:KUALI</param>
 	<param name="datasource.username">KRADEV</param>
 	<param name="datasource.password">ask your team</param>
-	
+
 	<!-- overriding from rice's default - remove override once rice's changes their default -->
 	<param name="datasource.pool.maxSize">20</param>
-	
+
 	<!-- Rice Server DB -->
 	<!-- Should be the same as KC Client DB when running bundled mode -->
 	<param name="server.datasource.url">${datasource.url}</param>
@@ -118,7 +118,12 @@
 	<param name="server.datasource.pool.maxSize">${datasource.pool.maxSize}</param>
 	<param name="server.datasource.pool.size">${datasource.pool.size}</param>
 	<param name="server.datasource.connectionTimeout">${datasource.connectionTimeout}</param>
-    <param name="server.datasource.pool.class">${datasource.pool.class}</param>
+	<param name="server.datasource.pool.class">${datasource.pool.class}</param>
+	<param name="server.datasource.pool.class.non.xa">${datasource.pool.class.non.xa}</param>
+	<param name="server.datasource.pool.maxActive">${datasource.pool.maxActive}</param>
+	<param name="server.datasource.minIdle">${datasource.minIdle}</param>
+	<param name="server.datasource.initialSize">${datasource.initialSize}</param>
+	<param name="server.datasource.accessToUnderlyingConnectionAllowed">${datasource.accessToUnderlyingConnectionAllowed}</param>
 
 	<param name="keystore.alias">onestartsharedservices-devandtst</param>
 	<param name="keystore.file">kul</param>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/CommonComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/CommonComponentSpringBeans.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context
-       http://www.springframework.org/schema/context/spring-context.xsd
-       http://www.springframework.org/schema/util
-       http://www.springframework.org/schema/util/spring-util.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
     <context:component-scan base-package="org.kuali.coeus.common.api" />
     <context:component-scan base-package="org.kuali.coeus.common.framework" />
@@ -22,7 +26,6 @@
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/common/impl/CommonImportRiceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/common/impl/CommonImportModuleSpringBeans.xml"/>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/CommonImportRiceSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/CommonImportRiceSpringBeans.xml
@@ -49,7 +49,6 @@
     <bean id="rice.ksb.serviceBus" parent="grlImporter" p:serviceName="rice.ksb.serviceBus" />
     <bean id="documentService" parent="grlImporter" p:serviceName="documentService" />
     <bean id="functionRepositoryService" parent="grlImporter" p:serviceName="functionRepositoryService" />
-    <bean id="dataSource" parent="grlImporter" p:serviceName="dataSource" />
     <bean id="maintenanceDocumentDictionaryService" parent="grlImporter" p:serviceName="maintenanceDocumentDictionaryService" />
     <bean id="pessimisticLockService" parent="grlImporter" p:serviceName="pessimisticLockService" />
     <bean id="lookupDao" parent="grlImporter" p:serviceName="lookupDao" />
@@ -68,4 +67,8 @@
     <bean id="kradApplicationDataSource" parent="grlImporter" p:serviceName="kradApplicationDataSource"/>
     <bean id="documentTypeService" parent="grlImporter" p:serviceName="rice.kew.documentTypeService" />
 
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevComponentSpringBeans.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context
-       http://www.springframework.org/schema/context/spring-context.xsd
-       http://www.springframework.org/schema/util
-       http://www.springframework.org/schema/util/spring-util.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
     <context:component-scan base-package="org.kuali.coeus.propdev" />
 
@@ -18,7 +22,6 @@
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/propdev/impl/PropDevImportRiceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/propdev/impl/PropDevImportModuleSpringBeans.xml"/>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevImportRiceSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/PropDevImportRiceSpringBeans.xml
@@ -77,4 +77,8 @@
     <bean id="refreshControllerService" parent="grlImporter" p:serviceName="refreshControllerService" />
     <bean id="documentAdHocService" parent="grlImporter" p:serviceName="documentAdHocService" />
 
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml
@@ -20,18 +20,10 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:p="http://www.springframework.org/schema/p"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context.xsd
-
-
-                           http://www.springframework.org/schema/tx
-                           http://www.springframework.org/schema/tx/spring-tx.xsd
-                           http://www.springframework.org/schema/aop
-                           http://www.springframework.org/schema/aop/spring-aop.xsd">
+                           http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:annotation-config />
 
@@ -40,20 +32,8 @@
     <bean id="grlImporter" abstract="true" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean" p:singleton="true" p:mustExist="true" />
 
     <bean id="kualiModuleService" parent="grlImporter" p:serviceName="kualiModuleService" />
-    <bean id="transactionManager" parent="grlImporter" p:serviceName="transactionManager" />
+    <bean id="parameterService" parent="grlImporter" p:serviceName="parameterService" />
     <bean id="modelAndViewService" parent="grlImporter" p:serviceName="modelAndViewService" />
-
-    <tx:advice id="txAdvice" transaction-manager="transactionManager">
-        <tx:attributes>
-            <tx:method name="*"/>
-        </tx:attributes>
-    </tx:advice>
-
-    <aop:config>
-        <aop:pointcut id="controllerTransaction"
-                      expression="execution(* org.kuali.rice.krad.web.controller.UifControllerBase+.*(..))"/>
-        <aop:advisor advice-ref="txAdvice" pointcut-ref="controllerTransaction"/>
-    </aop:config>
 
     <bean class="org.kuali.rice.krad.uif.freemarker.FreeMarkerInlineRenderBootstrap" />
 

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/DataSourceSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/DataSourceSpringBeans.xml
@@ -19,6 +19,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
@@ -26,15 +27,24 @@
 
     <context:annotation-config />
 
-    <!-- this spring file is meant to be imported into other modules as needed -->
-
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/rice/core/RiceJTASpringBeans.xml"/>
+    <bean id="transactionManagerXAPool" class="org.kuali.rice.core.impl.util.spring.RiceJotmFactoryBean">
+        <property name="defaultTimeout" value="${transaction.timeout}"/>
+    </bean>
 
-	<bean id="riceDataSourceXAPool" class="org.kuali.rice.core.framework.persistence.jdbc.datasource.XAPoolDataSource">
+    <bean id="btmConfig" factory-method="getConfiguration" class="bitronix.tm.TransactionManagerServices" lazy-init="true">
+    </bean>
+
+    <bean id="transactionManagerBitronix" class="bitronix.tm.TransactionManagerServices"
+          factory-method="getTransactionManager" depends-on="btmConfig" destroy-method="shutdown" lazy-init="true"/>
+
+    <alias name="transactionManager${connection.pool.impl}" alias="jtaTransactionManager"/>
+    <alias name="transactionManager${connection.pool.impl}" alias="jtaUserTransaction"/>
+
+	<bean id="riceDataSourceXAPool" class="org.kuali.rice.core.framework.persistence.jdbc.datasource.XAPoolDataSource" lazy-init="true">
 		<property name="transactionManager" ref="transactionManagerXAPool" />
 		<property name="driverClassName" value="${server.datasource.driver.name}" />
 		<property name="url" value="${server.datasource.url}" />
@@ -45,8 +55,8 @@
 		<property name="username" value="${server.datasource.username}" />
 		<property name="password" value="${server.datasource.password}" />
 	</bean>
-	
-	<bean id="dataSourceXAPool" class="org.kuali.rice.core.framework.persistence.jdbc.datasource.XAPoolDataSource">
+
+	<bean id="dataSourceXAPool" class="org.kuali.rice.core.framework.persistence.jdbc.datasource.XAPoolDataSource" lazy-init="true">
 		<property name="transactionManager" ref="transactionManagerXAPool" />
 		<property name="driverClassName" value="${datasource.driver.name}" />
 		<property name="url" value="${datasource.url}" />
@@ -60,7 +70,7 @@
 
   <bean id="riceDataSourceBitronix" class="bitronix.tm.resource.jdbc.PoolingDataSource" init-method="init"
         destroy-method="close" lazy-init="true">
-    <property name="className" value="${datasource.pool.class.non.xa}" />
+    <property name="className" value="${server.datasource.pool.class.non.xa}" />
     <property name="uniqueName" value="#{T(org.apache.commons.lang3.RandomStringUtils).randomAlphanumeric(20)}" />
     <property name="minPoolSize" value="${server.datasource.pool.minSize}" />
     <property name="maxPoolSize" value="${server.datasource.pool.maxSize}" />
@@ -95,10 +105,10 @@
       </props>
     </property>
   </bean>
-  
+
   <bean id="riceDataSourceBitronixXa" class="bitronix.tm.resource.jdbc.PoolingDataSource" init-method="init"
  	      destroy-method="close" lazy-init="true">
-    <property name="className" value="${datasource.pool.class}" />
+    <property name="className" value="${server.datasource.pool.class}" />
     <property name="uniqueName" value="#{T(org.apache.commons.lang3.RandomStringUtils).randomAlphanumeric(20)}" />
     <property name="minPoolSize" value="${server.datasource.pool.minSize}" />
     <property name="maxPoolSize" value="${server.datasource.pool.maxSize}" />
@@ -131,11 +141,11 @@
       </props>
     </property>
   </bean>
-  
+
   <alias name="riceDataSource${connection.pool.impl}" alias="riceDataSource"/>
   <alias name="dataSource${connection.pool.impl}" alias="dataSource"/>
 
-   <bean id="nonTransactionalDataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+   <bean id="nonTransactionalDataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close" lazy-init="true">
        <property name="driverClassName" value="${datasource.driver.name}"/>
        <property name="url" value="${datasource.url}"/>
        <property name="maxActive" value="${datasource.pool.maxActive}"/>
@@ -147,32 +157,10 @@
        <property name="accessToUnderlyingConnectionAllowed" value="${datasource.accessToUnderlyingConnectionAllowed}"/>
    </bean>
 
-   <bean id="transactionManager" class="org.springframework.transaction.jta.JtaTransactionManager" lazy-init="true">
-        <property name="userTransaction" ref="jtaUserTransaction"/>
-        <property name="transactionManager" ref="jtaTransactionManager"/>
-   </bean>
-
-    <bean id="transactionAdvisor" class="org.springframework.transaction.interceptor.TransactionAttributeSourceAdvisor">
-        <property name="classFilter" ref="transactionAdvisorClassFilter" />
-        <property name="transactionInterceptor" ref="transactionInterceptor" />
+    <bean id="transactionManager"
+          class="org.springframework.transaction.jta.JtaTransactionManager"
+          p:userTransaction-ref="jtaUserTransaction"
+          p:transactionManager-ref="jtaTransactionManager">
     </bean>
-
-    <bean id="transactionAdvisorClassFilter" class="org.kuali.rice.core.framework.util.spring.ClassOrMethodAnnotationFilter">
-        <constructor-arg value="org.springframework.transaction.annotation.Transactional" />
-    </bean>
-
-    <bean id="transactionInterceptor" class="org.kuali.rice.core.framework.persistence.jta.KualiTransactionInterceptor">
-        <property name="transactionManager" ref="transactionManager" />
-        <property name="transactionAttributeSource" ref="transactionAttributeSource" />
-    </bean>
-
-    <bean id="transactionAttributeSource" class="org.kuali.rice.core.impl.util.spring.AnnotationAndNameMatchingTransactionAttributeSource">
-        <property name="annotationTransactionAttributeSource" ref="annotationTransactionAttributeSource" />
-        <property name="transactionTimeout" value="${transaction.timeout}" />
-    </bean>
-
-    <bean id="annotationTransactionAttributeSource" class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource" />
-
-    <bean id="commonDefaultAdvisorAutoProxyCreator" class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator" />
 
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/RiceBootstrapSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/RiceBootstrapSpringBeans.xml
@@ -9,26 +9,27 @@
 
     <context:annotation-config />
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <import resource="classpath:org/kuali/coeus/sys/impl/DataSourceSpringBeans.xml"/>
 
     <bean id="coreConfigurer" class="org.kuali.rice.core.impl.config.module.CoreConfigurer">
-        <property name="dataSource" ref="dataSource${connection.pool.impl}" />
-        <property name="serverDataSource" ref="riceDataSource${connection.pool.impl}" />
+        <property name="dataSource" ref="dataSource" />
+        <property name="serverDataSource" ref="riceDataSource" />
         <property name="nonTransactionalDataSource" ref="nonTransactionalDataSource" />
-        <property name="transactionManager" ref="transactionManager${connection.pool.impl}" />
+        <property name="transactionManager" ref="jtaTransactionManager" />
         <property name="userTransaction" ref="jtaUserTransaction" />
     </bean>
 
     <bean id="ksbConfigurer" class="org.kuali.rice.ksb.messaging.config.KSBConfigurer">
-        <property name="registryDataSource" ref="riceDataSource${connection.pool.impl}" />
-        <property name="messageDataSource" ref="riceDataSource${connection.pool.impl}" />
+        <property name="registryDataSource" ref="riceDataSource" />
+        <property name="messageDataSource" ref="riceDataSource" />
         <property name="nonTransactionalMessageDataSource" ref="nonTransactionalDataSource" />
-        <property name="bamDataSource" ref="riceDataSource${connection.pool.impl}" />
+        <property name="bamDataSource" ref="riceDataSource" />
+        <property name="platformTransactionManager" ref="transactionManager" />
     </bean>
 
     <bean id="kradConfigurer" class="org.kuali.rice.krad.config.KRADConfigurer">
         <property name="includeKnsSpringBeans" value="true" />
-        <property name="applicationDataSource" ref="dataSource${connection.pool.impl}" />
+        <property name="applicationDataSource" ref="dataSource" />
     </bean>
 
     <bean id="coreServiceConfigurer" class="org.kuali.rice.coreservice.impl.config.CoreServiceConfigurer" />
@@ -36,13 +37,15 @@
     <bean id="kimConfigurer" class="org.kuali.rice.kim.config.KIMConfigurer" />
 
     <bean id="kewConfigurer" class="org.kuali.rice.kew.config.KEWConfigurer">
-        <property name="dataSource" ref="riceDataSource${connection.pool.impl}" />
+        <property name="dataSource" ref="riceDataSource" />
     </bean>
 
     <bean id="kenConfigurer" class="org.kuali.rice.ken.impl.config.KENConfigurer" />
 
-    <bean id="krmsConfigurer" class="org.kuali.rice.krms.config.KRMSConfigurer"/>
+    <bean id="krmsConfigurer" class="org.kuali.rice.krms.config.KRMSConfigurer" />
 
     <bean id="locationConfigurer" class="org.kuali.rice.location.impl.config.LocationConfigurer" />
 
+    <!-- making sure OJB has the transaction manager set properly -->
+    <import resource="classpath:org/kuali/rice/core/CommonOJBSpringBeans.xml" />
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/SysComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/SysComponentSpringBeans.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context
-       http://www.springframework.org/schema/context/spring-context.xsd
-       http://www.springframework.org/schema/util
-       http://www.springframework.org/schema/util/spring-util.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
     <context:component-scan base-package="org.kuali.coeus.sys" />
 
@@ -17,7 +22,6 @@
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/sys/impl/SysImportRiceSpringBeans.xml"/>
     <import resource="classpath:org/kuali/coeus/sys/impl/SysImportModuleSpringBeans.xml"/>
 

--- a/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/SysImportRiceSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/sys/impl/SysImportRiceSpringBeans.xml
@@ -24,7 +24,6 @@
     <bean id="dataObjectService" parent="grlImporter" p:serviceName="dataObjectService" />
     <bean id="documentDictionaryService" parent="grlImporter" p:serviceName="documentDictionaryService" />
     <bean id="maintenanceDocumentDictionaryService" parent="grlImporter" p:serviceName="maintenanceDocumentDictionaryService" />
-    <bean id="dataSource" parent="grlImporter" p:serviceName="dataSource" />
     <bean id="kualiRuleService" parent="grlImporter" p:serviceName="kualiRuleService"/>
     <bean id="lookupService" parent="grlImporter" p:serviceName="lookupService" />
     <bean id="sequenceAccessorService" parent="grlImporter" p:serviceName="sequenceAccessorService" />
@@ -44,4 +43,8 @@
     <bean id="refreshControllerService" parent="grlImporter" p:serviceName="refreshControllerService" />
     <bean id="saveControllerService" parent="grlImporter" p:serviceName="saveControllerService" />
 
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 </beans>

--- a/coeus-impl/src/main/resources/org/kuali/kra/CoreSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/CoreSpringBeans.xml
@@ -16,16 +16,20 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <context:component-scan base-package="org.kuali.coeus.common.notification.impl.service.impl"/>
@@ -36,7 +40,11 @@
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
+
     <import resource="classpath:org/kuali/coeus/sys/framework/ImportRiceKradSpringBeans.xml"/>
     <import resource="classpath:org/kuali/rice/krad/config/KRADDependentModuleCommonImports.xml" />
 
@@ -1395,10 +1403,6 @@
 		parent="parentLookupableHelperService" scope="prototype" />
 
     <!-- Cross-Module Services -->
-
-    <bean id="dataSource" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
-        <property name="serviceName" value="dataSource" />
-    </bean>
 
     <bean id="awardService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
         <property name="serviceName" value="awardService" />

--- a/coeus-impl/src/main/resources/org/kuali/kra/award/AwardSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/award/AwardSpringBeans.xml
@@ -14,25 +14,34 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
+
     <util:constant id="kc.integrationServiceNamespace" static-field="org.kuali.kra.infrastructure.Constants.FINANCIAL_INTEGRATION_KC_SERVICE_NAMESPACE"/>
     
     <bean id="awardModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">

--- a/coeus-impl/src/main/resources/org/kuali/kra/coi/CoiSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/coi/CoiSpringBeans.xml
@@ -16,23 +16,30 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 
     <bean id="coiModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
         <property name="moduleConfiguration" ref="coiModuleConfiguration"/>

--- a/coeus-impl/src/main/resources/org/kuali/kra/institutionalproposal/InstitutionalProposalSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/institutionalproposal/InstitutionalProposalSpringBeans.xml
@@ -16,16 +16,20 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <context:component-scan base-package="org.kuali.coeus.instprop"/>
@@ -34,7 +38,10 @@
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 
     <bean id="institutionalProposalModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
         <property name="moduleConfiguration" ref="institutionalProposalModuleConfiguration"/>

--- a/coeus-impl/src/main/resources/org/kuali/kra/negotiation/NegotiationSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/negotiation/NegotiationSpringBeans.xml
@@ -16,23 +16,30 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 
     <bean id="negotiationModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
         <property name="moduleConfiguration" ref="negotiationModuleConfiguration"/>

--- a/coeus-impl/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
@@ -16,23 +16,30 @@ R
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx.xsd
                            http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <tx:annotation-driven transaction-manager="transactionManager" />
     <context:annotation-config />
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="properties" value="#{T(org.kuali.rice.core.api.config.property.ConfigContext).getCurrentContextConfig().getProperties()}" />
     </bean>
 
-    <import resource="classpath:org/kuali/coeus/sys/framework/ImportDataSourceSpringBeans.xml"/>
+    <bean id="ccImporter" abstract="true" class="org.kuali.coeus.sys.framework.service.ConfigContextConfigObjectFactoryBean" p:singleton="true" p:mustExist="true" />
+
+    <bean id="dataSource" parent="ccImporter" p:objectName="datasource" />
+    <bean id="transactionManager" parent="ccImporter" p:objectName="SPRING_TRANSACTION_MANAGER" />
 
     <bean id="subAwardModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
         <property name="moduleConfiguration" ref="subAwardModuleConfiguration"/>


### PR DESCRIPTION
...ontext.

This PR does several things:

1) it ensures that the datasources, transaction managers, and connection pools are only created once for the entire application and imported into other spring contexts.
2) Using the standard Spring Transaction Interceptor and standard transaction configuration.
