### PR TITLE
KRACOEUS-8859:budget pessimistic locking

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/auth/ProposalBudgetAuthorizer.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/auth/ProposalBudgetAuthorizer.java
@@ -23,14 +23,17 @@ import org.kuali.coeus.propdev.impl.budget.ProposalDevelopmentBudgetExt;
 import org.kuali.coeus.propdev.impl.budget.core.ProposalBudgetConstants.AuthConstants;
 import org.kuali.coeus.propdev.impl.budget.core.ProposalBudgetForm;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocument;
+import org.kuali.coeus.propdev.impl.lock.ProposalBudgetLockService;
 import org.kuali.coeus.sys.framework.workflow.KcDocumentRejectionService;
 import org.kuali.coeus.sys.framework.workflow.KcWorkflowService;
+import org.kuali.kra.authorization.KraAuthorizationConstants;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.PermissionConstants;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kns.authorization.AuthorizationConstants;
 import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.document.authorization.PessimisticLock;
 import org.kuali.rice.krad.uif.view.View;
 import org.kuali.rice.krad.uif.view.ViewAuthorizerBase;
 import org.kuali.rice.krad.uif.view.ViewModel;
@@ -62,6 +65,10 @@ public class ProposalBudgetAuthorizer extends ViewAuthorizerBase {
     @Autowired
     @Qualifier("kcWorkflowService")
     private KcWorkflowService kcWorkflowService;
+
+    @Autowired
+    @Qualifier("proposalBudgetLockService")
+    private ProposalBudgetLockService proposalBudgetLockService;
 
     @Override
     public Set<String> getEditModes(View view, ViewModel model, Person user, Set<String> editModes) {
@@ -192,7 +199,17 @@ public class ProposalBudgetAuthorizer extends ViewAuthorizerBase {
 
         return (!getKcWorkflowService().isInWorkflow(pdDocument) || rejectedDocument) &&
                 getKcAuthorizationService().hasPermission(user.getPrincipalId(), pdDocument, PermissionConstants.MODIFY_BUDGET) 
-                && !pdDocument.getDevelopmentProposal().getSubmitFlag();
+                && !pdDocument.getDevelopmentProposal().getSubmitFlag() && userHasLockOnBudget(budget,user);
+    }
+
+    protected boolean userHasLockOnBudget(ProposalDevelopmentBudgetExt budget, Person user) {
+        ProposalDevelopmentDocument document = budget.getDevelopmentProposal().getProposalDocument();
+        for (PessimisticLock lock : document.getPessimisticLocks()) {
+            if (lock.isOwnedByUser(user) && getProposalBudgetLockService().doesBudgetVersionMatchDescriptor(lock.getLockDescriptor(),budget.getBudgetVersionNumber())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected boolean isAuthorizedToAddBudget(Document document, Person user) {
@@ -243,5 +260,13 @@ public class ProposalBudgetAuthorizer extends ViewAuthorizerBase {
 
     public void setKcWorkflowService(KcWorkflowService kcWorkflowService) {
         this.kcWorkflowService = kcWorkflowService;
+    }
+
+    public ProposalBudgetLockService getProposalBudgetLockService() {
+        return proposalBudgetLockService;
+    }
+
+    public void setProposalBudgetLockService(ProposalBudgetLockService proposalBudgetLockService) {
+        this.proposalBudgetLockService = proposalBudgetLockService;
     }
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetControllerBase.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetControllerBase.java
@@ -174,7 +174,7 @@ public abstract class ProposalBudgetControllerBase {
     protected ModelAndView navigate(ProposalBudgetForm form) throws Exception {
 		form.setPageId(form.getActionParamaterValue(UifParameters.NAVIGATE_TO_PAGE_ID));
 		form.setDirtyForm(false);
-		if (form.getView().getCurrentPage().getReadOnly() != null && form.getView().getCurrentPage().getReadOnly()) {
+		if (form.isCanEditView()) {
 			return getModelAndViewService().getModelAndView(form);
 		} else {
 			return save(form);

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetSharedControllerServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetSharedControllerServiceImpl.java
@@ -53,7 +53,7 @@ public class ProposalBudgetSharedControllerServiceImpl implements ProposalBudget
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("modularBudgetFlag", modularBudget != null ? modularBudget : Boolean.FALSE);
 		if (kcBusinessRulesEngine.applyRules(new ProposalAddBudgetVersionEvent("addBudgetDto", developmentProposal, budgetName))) {
-			budget = (ProposalDevelopmentBudgetExt) getBudgetService().addBudgetVersion(developmentProposal.getDocument(), budgetName, options);	
+			budget = (ProposalDevelopmentBudgetExt) getBudgetService().addBudgetVersion(developmentProposal.getDocument(), budgetName, options);
 		}
         if (budget != null) {
 	        Properties props = new Properties();

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.java
@@ -1,0 +1,76 @@
+package org.kuali.coeus.propdev.impl.budget.core;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.coeus.propdev.impl.lock.ProposalBudgetLockService;
+import org.kuali.coeus.sys.framework.service.KcServiceLocator;
+import org.kuali.coeus.sys.impl.lock.PessimisticLockConstants;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.krad.document.authorization.PessimisticLock;
+import org.kuali.rice.krad.uif.util.LifecycleElement;
+import org.kuali.rice.krad.uif.view.FormView;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
+
+public class ProposalBudgetView extends FormView {
+
+    private static final String KC_ERROR_TRANSACTIONAL_LOCKED = "kc.error.transactional.locked.budget";
+    private static final String ERROR_TRANSACTIONAL_LOCKED = "error.transactional.locked.budget";
+
+    private ParameterService parameterService;
+    private ProposalBudgetLockService proposalBudgetLockService;
+
+    @Override
+    public void performFinalize(Object model, LifecycleElement parent) {
+        super.performFinalize(model, parent);
+        generatePessimisticLockMessages((ProposalBudgetForm) model);
+        ((ProposalBudgetForm) model).setCanEditView(!this.getReadOnly());
+    }
+
+    protected void generatePessimisticLockMessages(ProposalBudgetForm form) {
+        Document document = form.getBudget().getDevelopmentProposal().getDocument();
+        Person user = GlobalVariables.getUserSession().getPerson();
+        int budgetVersion = form.getBudget().getBudgetVersionNumber();
+        for (PessimisticLock lock : document.getPessimisticLocks()) {
+            if (!lock.isOwnedByUser(user) && getProposalBudgetLockService().doesBudgetVersionMatchDescriptor(lock.getLockDescriptor(),budgetVersion)) {
+                String lockDescriptor = StringUtils.defaultIfBlank(lock.getLockDescriptor(), "full");
+                String lockOwner = lock.getOwnedByUser().getName();
+                String lockTime = RiceConstants.getDefaultTimeFormat().format(lock.getGeneratedTimestamp());
+                String lockDate = RiceConstants.getDefaultDateFormat().format(lock.getGeneratedTimestamp());
+
+                if (!getParameterService().getParameterValueAsBoolean("KC-GEN", "All", PessimisticLockConstants.ALLOW_CLEAR_PESSIMISTIC_LOCK_PARM)) {
+                    GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS,
+                            ERROR_TRANSACTIONAL_LOCKED, lockDescriptor, lockOwner, lockTime, lockDate);
+                } else {
+                    GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS,
+                            KC_ERROR_TRANSACTIONAL_LOCKED, lockDescriptor, lockOwner, lockTime, lockDate, lock.getId().toString());
+                }
+            }
+        }
+    }
+
+    public ParameterService getParameterService() {
+        if (parameterService == null) {
+            parameterService = KcServiceLocator.getService(ParameterService.class);
+        }
+
+        return parameterService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+    public ProposalBudgetLockService getProposalBudgetLockService() {
+        if (proposalBudgetLockService == null) {
+            proposalBudgetLockService = KcServiceLocator.getService(ProposalBudgetLockService.class);
+        }
+        return proposalBudgetLockService;
+    }
+
+    public void setProposalBudgetLockService(ProposalBudgetLockService proposalBudgetLockService) {
+        this.proposalBudgetLockService = proposalBudgetLockService;
+    }
+}

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/lock/ProposalBudgetLockService.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/lock/ProposalBudgetLockService.java
@@ -1,0 +1,9 @@
+package org.kuali.coeus.propdev.impl.lock;
+
+import org.kuali.coeus.propdev.impl.budget.ProposalDevelopmentBudgetExt;
+
+public interface ProposalBudgetLockService {
+    public void establishBudgetLock(ProposalDevelopmentBudgetExt budget);
+    public void deleteBudgetLock(ProposalDevelopmentBudgetExt budget);
+    public boolean doesBudgetVersionMatchDescriptor(String lockDescriptor, int budgetVersionNumber);
+}

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/lock/ProposalBudgetLockServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/lock/ProposalBudgetLockServiceImpl.java
@@ -1,0 +1,143 @@
+package org.kuali.coeus.propdev.impl.lock;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kuali.coeus.common.budget.framework.core.Budget;
+import org.kuali.coeus.propdev.impl.budget.ProposalDevelopmentBudgetExt;
+import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocument;
+import org.kuali.coeus.sys.framework.gv.GlobalVariableService;
+import org.kuali.kra.authorization.KraAuthorizationConstants;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.krad.data.DataObjectService;
+import org.kuali.rice.krad.document.authorization.PessimisticLock;
+import org.kuali.rice.krad.service.DataDictionaryService;
+import org.kuali.rice.krad.service.PessimisticLockService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Component("proposalBudgetLockService")
+@Transactional
+public class ProposalBudgetLockServiceImpl implements ProposalBudgetLockService {
+
+    @Autowired
+    @Qualifier("dataObjectService")
+    private DataObjectService dataObjectService;
+
+    @Autowired
+    @Qualifier("dataDictionaryService")
+    protected DataDictionaryService dataDictionaryService;
+
+    @Autowired
+    @Qualifier("globalVariableService")
+    protected GlobalVariableService globalVariableService;
+
+    @Autowired
+    @Qualifier("pessimisticLockService")
+    protected PessimisticLockService pessimisticLockService;
+
+    @Override
+    public void establishBudgetLock(ProposalDevelopmentBudgetExt budget){
+        ProposalDevelopmentDocument document = budget.getDevelopmentProposal().getProposalDocument();
+        if (isPessimisticLockNeeded(document, budget, getGlobalVariableService().getUserSession().getPerson(),true)) {
+            PessimisticLock pessimisticLock = getPessimisticLockService().generateNewLock(document.getDocumentNumber(),
+                    getBudgetLockDescriptor(document.getDevelopmentProposal().getProposalNumber(),
+                            budget.getBudgetVersionNumber()),
+                            getGlobalVariableService().getUserSession().getPerson());
+            document.addPessimisticLock(pessimisticLock);
+        }
+    }
+
+    @Override
+    public void deleteBudgetLock(ProposalDevelopmentBudgetExt budget) {
+        ProposalDevelopmentDocument document = budget.getDevelopmentProposal().getProposalDocument();
+        for (PessimisticLock lock : document.getPessimisticLocks()) {
+            if (lock.isOwnedByUser(getGlobalVariableService().getUserSession().getPerson()) &&
+                    doesBudgetVersionMatchDescriptor(lock.getLockDescriptor(), budget.getBudgetVersionNumber())) {
+                getDataObjectService().delete(lock);
+            }
+        }
+        document.refreshPessimisticLocks();
+    }
+
+    @Override
+    public boolean doesBudgetVersionMatchDescriptor(String lockDescriptor, int budgetVersionNumber) {
+        String[] lockDescriptorValues = StringUtils.split(lockDescriptor,"-");
+        return lockDescriptorValues.length == 3 &&
+                StringUtils.equals(lockDescriptorValues[1], KraAuthorizationConstants.LOCK_DESCRIPTOR_BUDGET) &&
+                StringUtils.isNotEmpty(lockDescriptorValues[2]) &&
+                Integer.parseInt(lockDescriptorValues[2]) == budgetVersionNumber;
+    }
+
+    protected boolean isPessimisticLockNeeded(ProposalDevelopmentDocument document, Budget budget, Person user, boolean canEdit) {
+        List<String> userOwnedLockDescriptors = new ArrayList<String>();
+        Map<String, Set<String>> otherOwnedLockDescriptors = new HashMap<String,Set<String>>();
+
+        // create the two lock containers that help determine whether to add a pessimistic lock
+        for (PessimisticLock pessimisticLock : document.getPessimisticLocks()) {
+            if (pessimisticLock.isOwnedByUser(user)) {
+                userOwnedLockDescriptors.add(pessimisticLock.getLockDescriptor());
+            } else {
+                if (!otherOwnedLockDescriptors.containsKey(pessimisticLock.getLockDescriptor())) {
+                    otherOwnedLockDescriptors.put(pessimisticLock.getLockDescriptor(), new HashSet<String>());
+                }
+
+                String otherOwnerPrincipalId = pessimisticLock.getOwnedByUser().getPrincipalId();
+                otherOwnedLockDescriptors.get(pessimisticLock.getLockDescriptor()).add(otherOwnerPrincipalId);
+            }
+        }
+
+        // if no one has a lock on this document, then the document can be locked if the user can edit it
+        if (userOwnedLockDescriptors.isEmpty() && otherOwnedLockDescriptors.isEmpty()) {
+            return canEdit;
+        }
+
+        String customLockDescriptor = getBudgetLockDescriptor(document.getDevelopmentProposal().getProposalNumber(),budget.getBudgetVersionNumber());
+        boolean userOwnsCustomLockDescriptor = userOwnedLockDescriptors.contains(customLockDescriptor);
+        boolean otherOwnsCustomLockDescriptor = otherOwnedLockDescriptors.containsKey(customLockDescriptor);
+
+        if (!userOwnsCustomLockDescriptor && !otherOwnsCustomLockDescriptor) {
+            return canEdit;
+        }
+
+        return false;
+    }
+
+    protected String getBudgetLockDescriptor(String proposalNumber, int budgetVersion) {
+        return proposalNumber + "-" + KraAuthorizationConstants.LOCK_DESCRIPTOR_BUDGET + "-" +budgetVersion;
+    }
+
+    public DataDictionaryService getDataDictionaryService() {
+        return dataDictionaryService;
+    }
+
+    public void setDataDictionaryService(DataDictionaryService dataDictionaryService) {
+        this.dataDictionaryService = dataDictionaryService;
+    }
+
+    public DataObjectService getDataObjectService() {
+        return dataObjectService;
+    }
+
+    public void setDataObjectService(DataObjectService dataObjectService) {
+        this.dataObjectService = dataObjectService;
+    }
+
+    public GlobalVariableService getGlobalVariableService() {
+        return globalVariableService;
+    }
+
+    public void setGlobalVariableService(GlobalVariableService globalVariableService) {
+        this.globalVariableService = globalVariableService;
+    }
+
+    public PessimisticLockService getPessimisticLockService() {
+        return pessimisticLockService;
+    }
+
+    public void setPessimisticLockService(PessimisticLockService pessimisticLockService) {
+        this.pessimisticLockService = pessimisticLockService;
+    }
+}

--- a/coeus-impl/src/main/resources/ApplicationResources.properties
+++ b/coeus-impl/src/main/resources/ApplicationResources.properties
@@ -1100,6 +1100,8 @@ error.unique.doc.access.entry=Non unique combination of document number, princip
 info.dataoverride.occured=A data override action has occurred on this proposal.
 
 kc.error.transactional.locked = This document currently has a {0} lock owned by {1} as of {2} on {3}. Click <a href="javascript:void(0)" onclick="Kc.PessimisticLock.clearLock({4});">here</a> to remove the lock.
+kc.error.transactional.locked.budget = This budget currently has a {0} lock owned by {1} as of {2} on {3}. Click <a href="javascript:void(0)" onclick="Kc.PessimisticLock.clearLock({4});">here</a> to remove the lock.
+error.transactional.locked.budget = This budget currently has a {0} lock owned by {1} as of {2} on {3}.
 error.generic={0}
 error.budgetPerson.calculationBase=Must be a value with no more than 10 digits before and two digits after the decimal point.
 error.ggtrackingid.required=Prev Grants.gov Tracking ID field is required when the Submission Type selected is Change/Corrected application and Proposal Type selected is "New"

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/budget/core/ProposalBudgetView.xml
@@ -15,7 +15,8 @@
 	<!-- Proposal Document View -->
 	<bean id="PropBudget-DefaultView" parent="PropBudget-DefaultView-parentBean" />
 	<bean id="PropBudget-DefaultView-parentBean" abstract="true"
-		parent="Uif-FormView" p:headerText="Budget #@{budget.budgetVersionNumber}: @{budget.name}"
+		parent="Uif-FormView" class="org.kuali.coeus.propdev.impl.budget.core.ProposalBudgetView"
+        p:headerText="Budget #@{budget.budgetVersionNumber}: @{budget.name}"
 		p:viewHelperService="#{#getService('proposalBudgetViewHelperService')}"
 		p:authorizer="#{#getService('proposalBudgetAuthorizer')}"
 		p:stickyApplicationHeader="true" p:stickyFooter="true"


### PR DESCRIPTION
created mechanism to lock individual budgets.

1.) when a budget version is created or opened a budget lock is generated for that budget version if one doesn't already exist.
2.) when a user clicks on return to proposal the budget lock is destroyed, else will remain until lock clean up occurs.
3.) no saves or edits are allowed if user doesn't own lock on budget. 
4.) if a user doesn't have a lock on a budget and the budget is read only, added messaging to display lock info.
