### PR TITLE
KRACOEUS-8556: Refreshing document pessimistic locks to make sure the document is in sync with the db.

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
@@ -428,8 +428,8 @@ public abstract class ProposalDevelopmentControllerBase {
 
         if (!document.getPessimisticLocks().isEmpty()) {
             Person user = getGlobalVariableService().getUserSession().getPerson();
-            getPessimisticLockService().releaseAllLocksForUser(document.getPessimisticLocks(), user);
             document.refreshPessimisticLocks();
+            getPessimisticLockService().releaseAllLocksForUser(document.getPessimisticLocks(), user);
         }
     }
     


### PR DESCRIPTION
This isn't the most ideal fix, as it doesn't fix the underlying issue.  But will resolve the blocker.
