### PR TITLE
KRACOEUS-8551:fixes STE where we try to delete and add a budget person i...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/hierarchy/ProposalHierarchyServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/hierarchy/ProposalHierarchyServiceImpl.java
@@ -1271,7 +1271,6 @@ public class ProposalHierarchyServiceImpl implements ProposalHierarchyService {
         for (Iterator<BudgetPerson> iter = parentBudget.getBudgetPersons().iterator(); iter.hasNext(); ) {
         	BudgetPerson person = iter.next();
         	if (StringUtils.equals(childProposalNumber, person.getHierarchyProposalNumber())) {
-        		dataObjectService.delete(person);
         		iter.remove();
         	}
         }


### PR DESCRIPTION
...n the same transaction

1.) by removing the granule delete of bugdet person we don't try to delete and save a budget person in the same persistence session.
2.)If the person is removed from the parent budget, and then not added later it in synchronize budget it will be deleted on the budget save.
