### PR TITLE
KULRICE-14083 isCurrentQuestionnaire refactor

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/framework/core/QuestionnaireConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/framework/core/QuestionnaireConstants.java
@@ -7,7 +7,8 @@ public final class QuestionnaireConstants {
 	 */
 	public static final String QUESTIONNAIRE_ID_PARAMETER_NAME = "id";
 	public static final String QUESTIONNAIRE_SEQUENCE_ID_PARAMETER_NAME = "questionnaireSeqId";
-	
+	public static final String QUESTIONNAIRE_SEQUENCE_NUMBER_PARAMETER_NAME = "sequenceNumber";
+
 	public static final String QUESTION_SEQEQUENCE_ID = "questionSeqId";
 	public static final String QUESTION_ID = "id";
 	

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/QuestionnaireDao.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/QuestionnaireDao.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.coeus.common.questionnaire.impl;
+
+/**
+ * @author Kuali Rice Team (rice.collab@kuali.org)
+ */
+public interface QuestionnaireDao {
+
+    /**
+     * Retrieve the sequence number for the questionnaire that is current.
+     *
+     * @param questionnaireSeqId the id of a specific questionnaire
+     * @return the current sequence number for the questionnaire, null if not found
+     */
+    public Integer getCurrentQuestionnaireSequenceNumber(String questionnaireSeqId);
+
+}

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/QuestionnaireDaoOjb.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/QuestionnaireDaoOjb.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.coeus.common.questionnaire.impl;
+
+import java.math.BigDecimal;
+import java.util.Iterator;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryFactory;
+import org.apache.ojb.broker.query.ReportQueryByCriteria;
+import org.kuali.coeus.common.questionnaire.framework.core.Questionnaire;
+import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireConstants;
+import org.kuali.rice.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
+
+/**
+ * @author Kuali Rice Team (rice.collab@kuali.org)
+ */
+public class QuestionnaireDaoOjb extends PlatformAwareDaoBaseOjb implements QuestionnaireDao {
+
+    @Override
+    public Integer getCurrentQuestionnaireSequenceNumber(String questionnaireSeqId) {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(QuestionnaireConstants.QUESTIONNAIRE_SEQUENCE_ID_PARAMETER_NAME, questionnaireSeqId);
+        String[] columns = {"max(" + QuestionnaireConstants.QUESTIONNAIRE_SEQUENCE_NUMBER_PARAMETER_NAME + ")"};
+        ReportQueryByCriteria query = QueryFactory.newReportQuery(Questionnaire.class, columns, criteria, false);
+        Iterator iter = getPersistenceBrokerTemplate().getReportQueryIteratorByQuery(query);
+        if (iter.hasNext()) {
+            Object[] objects = (Object[]) iter.next();
+            return ((BigDecimal) objects[0]).intValue();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireServiceImpl.java
@@ -18,6 +18,7 @@ package org.kuali.coeus.common.questionnaire.impl.core;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireService;
 import org.kuali.coeus.common.framework.auth.UnitAuthorizationService;
+import org.kuali.coeus.common.questionnaire.impl.QuestionnaireDao;
 import org.kuali.coeus.sys.framework.gv.GlobalVariableService;
 import org.kuali.kra.award.infrastructure.AwardPermissionConstants;
 import org.kuali.kra.infrastructure.Constants;
@@ -56,6 +57,10 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     @Autowired
     @Qualifier("globalVariableService")
     private GlobalVariableService globalVariableService;
+
+    @Autowired
+    @Qualifier("questionnaireDao")
+    private QuestionnaireDao questionnaireDao;
 
     private Map<String, String> permissionModuleMap;
 
@@ -165,10 +170,7 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     }
     
     public boolean isCurrentQuestionnaire(Questionnaire questionnaire) {
-        Map<String, String> fieldValues = new HashMap<String, String>();
-        fieldValues.put(QuestionnaireConstants.QUESTIONNAIRE_SEQUENCE_ID_PARAMETER_NAME, questionnaire.getQuestionnaireSeqId());
-        List<Questionnaire> questionnaires = (List<Questionnaire>) businessObjectService.findMatchingOrderBy(Questionnaire.class, fieldValues, "sequenceNumber", false);
-        return questionnaire.getId().equals(questionnaires.get(0).getId());
+        return questionnaire.getSequenceNumber().equals(getQuestionnaireDao().getCurrentQuestionnaireSequenceNumber(questionnaire.getQuestionnaireSeqId()));
     }
 
     public BusinessObjectService getBusinessObjectService() {
@@ -190,4 +192,13 @@ public class QuestionnaireServiceImpl implements QuestionnaireService {
     public void setGlobalVariableService(GlobalVariableService globalVariableService) {
         this.globalVariableService = globalVariableService;
     }
+
+    public void setQuestionnaireDao(QuestionnaireDao questionnaireDao) {
+        this.questionnaireDao = questionnaireDao;
+    }
+
+    public QuestionnaireDao getQuestionnaireDao() {
+        return questionnaireDao;
+    }
+
 }

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/questionnaire/impl/CommonQuestionnaireComponentSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/questionnaire/impl/CommonQuestionnaireComponentSpringBeans.xml
@@ -38,6 +38,13 @@
         </property>
     </bean>
 
+    <bean id="questionnaireDao" class="org.kuali.coeus.common.questionnaire.impl.QuestionnaireDaoOjb" parent="platformAwareDao"/>
+
+    <bean id="platformAwareDao" class="org.kuali.rice.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb" abstract="true">
+        <property name="jcdAlias" value="kradApplicationDataSource" />
+        <property name="dbPlatform" ref="dbPlatform" />
+    </bean>
+
     <bean id="questionResolverTypeServiceCallback" parent="kcCoreCallbackService"
           p:callbackService-ref="questionResolverTypeService"
           p:localServiceName="questionResolverTypeService"

--- a/coeus-it/src/test/java/org/kuali/kra/questionnaire/QuestionnaireDaoOjbTest.java
+++ b/coeus-it/src/test/java/org/kuali/kra/questionnaire/QuestionnaireDaoOjbTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl2.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.questionnaire;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kuali.coeus.common.questionnaire.impl.QuestionnaireDao;
+import org.kuali.coeus.common.questionnaire.impl.QuestionnaireDaoOjb;
+import org.kuali.coeus.sys.framework.service.KcServiceLocator;
+import org.kuali.kra.irb.Protocol;
+import org.kuali.kra.irb.ProtocolDocument;
+import org.kuali.kra.irb.ProtocolFinderDao;
+import org.kuali.kra.irb.test.ProtocolFactory;
+import org.kuali.kra.test.infrastructure.KcIntegrationTestBase;
+import org.kuali.rice.kew.api.exception.WorkflowException;
+import org.kuali.rice.krad.UserSession;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Kuali Rice Team (rice.collab@kuali.org)
+ */
+public class QuestionnaireDaoOjbTest {
+    private QuestionnaireDao questionnaireDao = new QuestionnaireDaoOjb();
+
+    private static final String QUESTIONNAIRE_SEQUENCE_ID = "1000";
+    private static final Integer CURRENT_QUESTIONNAIRE_SEQUENCE_NUMBER = 1;
+
+  @Test
+    public void testFindProtocol() throws WorkflowException {
+      assertEquals(CURRENT_QUESTIONNAIRE_SEQUENCE_NUMBER, questionnaireDao.getCurrentQuestionnaireSequenceNumber(QUESTIONNAIRE_SEQUENCE_ID));
+
+    }
+}


### PR DESCRIPTION
The QuestionnaireServiceImpl.isCurrentQuestionnaire method does a table scan and loads all questionnaires of a specific questionnaireSeqId. 

In my local install the table has only 18 records and at most two revision.  The isCurrentQuestionnaire method gets called either 10 times (20 if Questionnaire page is reloaded, i.e. not navigated to another page of the document).

Initially I though a performance gain could be achieved but final before/after testing didn't show any significant change for my local installation.

I'm not sure how the data of the questionnaire table will grow in an actual KC implementation and therefore leave it up to you to make the final decision about applying this code change.

It's suggested to add the following index for best performance:
  alter table questionnaire add index (questionnaire_id, sequence_number desc);