### PR TITLE
KRACOEUS-8608

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/framework/print/AttachmentDataSource.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/framework/print/AttachmentDataSource.java
@@ -34,7 +34,6 @@ public abstract class AttachmentDataSource extends KcPersistableBusinessObjectBa
     private String type;
 
     @Column(name = "DATA")
-    @Basic(fetch = FetchType.LAZY)
     @Lob
     private byte[] data;
 


### PR DESCRIPTION
KRACOEUS-8608
Validation error incorrectly shows attachment missing when attachment type exists
Issue here is that attachment in removed at some point.
I'm not able to reproduce this locally.
But I was able to in trunk, when I add an attachment, click save button at the bottom, navigate away
from attachments and back to attachment page, I see that attachment is wiped out.

@leoherbie as discussed, we can try this option - removing lazy on lob
