### PR TITLE
KRACOEUS-8618: Invalid error message upon IRB resubmission

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/ProtocolCorrespondence.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/ProtocolCorrespondence.xml
@@ -121,10 +121,10 @@
         <property name="shortLabel" value="Correspondence" />
         <property name="maxLength" value="4000" />
         <property name="validationPattern" >
-            <bean parent="AlphaNumericValidationPattern" />
+            <bean parent="AnyCharacterValidationPattern" />
         </property>
     <property name="validCharactersConstraint">
-      <bean parent="AlphaNumericPatternConstraint"/>
+      <bean parent="AnyCharacterPatternConstraint"/>
     </property>
         <property name="control" >
       <bean parent="TextControlDefinition" p:size="10"/>


### PR DESCRIPTION
Simply a matter of allowing any characters in correspondence contents (since correspondence is a PDF, it will have extended characters).