### PR TITLE
KRACOEUS-8678: Missing warning about invalid file type

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/framework/attachment/KcAttachmentService.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/framework/attachment/KcAttachmentService.java
@@ -15,6 +15,9 @@
  */
 package org.kuali.coeus.common.framework.attachment;
 
+import org.kuali.coeus.sys.api.model.KcFile;
+import org.kuali.coeus.sys.framework.validation.ErrorReporter;
+
 /**
  * KC Attachment Service.
  */
@@ -42,14 +45,6 @@ public interface KcAttachmentService {
    
         
     /**
-     * This method checks for invalid characters in strings and replaces
-     * them with underscores.
-     * @param text
-     * @return
-     */
-    String checkAndReplaceInvalidCharacters(String text);
-    
-    /**
      * This method checks for special characters in strings and replaces
      * them with underscores.
      * @param text
@@ -63,4 +58,14 @@ public interface KcAttachmentService {
      * @return
      */
     public String formatFileSizeString(Long size);
+
+    /**
+     * This method checks to see if the attachment is of type PDF
+     * @param fileInQuestion
+     * @param errorReporterService
+     * @param errorPrefix
+     * @return boolean
+     */
+    public boolean validPDFFile(KcFile fileInQuestion, ErrorReporter errorReporterService, String errorPrefix);
+
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/attachment/KcAttachmentServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/attachment/KcAttachmentServiceImpl.java
@@ -16,6 +16,10 @@
 package org.kuali.coeus.common.impl.attachment;
 
 import org.kuali.coeus.common.framework.attachment.KcAttachmentService;
+import org.kuali.coeus.sys.api.model.KcFile;
+import org.kuali.coeus.sys.framework.validation.ErrorReporter;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.krad.util.ObjectUtils;
 import org.springframework.stereotype.Component;
 
@@ -86,23 +90,6 @@ public class KcAttachmentServiceImpl implements KcAttachmentService {
         return null;    
     }
 
-    /**
-     * This method checks string for invalid characters and replaces with underscores.
-     */
-    @Override
-    public String checkAndReplaceInvalidCharacters(String text) {     
-        String cleanText = text;
-        if (ObjectUtils.isNotNull(text)) {
-            Pattern pattern = Pattern.compile(REGEX_TITLE_FILENAME_PATTERN);
-            Matcher matcher = pattern.matcher(text);
-            cleanText = matcher.replaceAll(REPLACEMENT_CHARACTER);
-            if(cleanText.length() > 50){
-               cleanText = cleanText.substring(0, 50);
-            }
-        }
-        return cleanText;
-    }
-
     @Override
     public boolean getSpecialCharacter(String text) {
         if (ObjectUtils.isNotNull(text)) {
@@ -136,6 +123,15 @@ public class KcAttachmentServiceImpl implements KcAttachmentService {
         } else {
             return format.format((((double)size) / 1000)) + " KB";
         }
+    }
+
+    @Override
+    public boolean validPDFFile(KcFile fileInQuestion, ErrorReporter errorReporter, String errorPrefix) {
+        if (!Constants.PDF_REPORT_CONTENT_TYPE.equals(fileInQuestion.getType())) {
+           errorReporter.reportWarning(errorPrefix, KeyConstants.INVALID_FILE_TYPE,
+                    fileInQuestion.getName(), Constants.PDF_REPORT_CONTENT_TYPE);
+        }
+        return true;
     }
 
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/ProposalDevelopmentNarrativeRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/ProposalDevelopmentNarrativeRule.java
@@ -50,7 +50,8 @@ public class ProposalDevelopmentNarrativeRule extends KcTransactionalDocumentRul
     private static final String DOCUMENT_NARRATIVES = "document.developmentProposal.narratives";
     private static final String PROPOSAL = "Proposal";
     private static final String MODULE_STATUS_CODE_COMPLETED = "C";
-    
+    private static final String ERROR_PREFIX_FOR_ATTACHMENTS = "multipartFile";
+
     private static final org.apache.commons.logging.Log LOG = org.apache.commons.logging.LogFactory.getLog(ProposalDevelopmentNarrativeRule.class);
     
     private transient KcPersonService kcPersonService;
@@ -84,7 +85,8 @@ public class ProposalDevelopmentNarrativeRule extends KcTransactionalDocumentRul
         rulePassed &= getDictionaryValidationService().isBusinessObjectValid(narrative);
         rulePassed &= checkNarrative(document.getDevelopmentProposal().getNarratives(), narrative);
         rulePassed &= validFileNameCharacters(narrative);
-        
+        rulePassed &= getKcFileService().validPDFFile(narrative, getErrorReporter(), ERROR_PREFIX_FOR_ATTACHMENTS);
+
         return rulePassed;
     }
     private boolean validFileNameCharacters(Narrative narrative) {
@@ -96,21 +98,20 @@ public class ProposalDevelopmentNarrativeRule extends KcTransactionalDocumentRul
         if (ObjectUtils.isNotNull(invalidCharacters)) {
             String parameter = getParameterService().
                                getParameterValueAsString(ProposalDevelopmentDocument.class, Constants.INVALID_FILE_NAME_CHECK_PARAMETER);
-           
+
             if (Constants.INVALID_FILE_NAME_ERROR_CODE.equals(parameter)) {
                 rulePassed &= false;
-                reportError("multipartFile", KeyConstants.INVALID_FILE_NAME,
+                reportError(ERROR_PREFIX_FOR_ATTACHMENTS, KeyConstants.INVALID_FILE_NAME,
                         attachmentFileName, invalidCharacters);
             } else {
                 rulePassed &= true;
-                reportWarning("multipartFile",KeyConstants.INVALID_FILE_NAME,
+                reportWarning(ERROR_PREFIX_FOR_ATTACHMENTS, KeyConstants.INVALID_FILE_NAME,
                         attachmentFileName, invalidCharacters);
-                GlobalVariables.getMessageMap().getErrorPath().clear();
-                GlobalVariables.getMessageMap().putWarning(DOCUMENT_NARRATIVES, KeyConstants.INVALID_FILE_NAME, attachmentFileName, invalidCharacters);
             }
         }
         return rulePassed;
     }
+
     /**
      * This method is used to validate narratives and institute proposal attachments before saving.
      * It checks whether the narratives are duplicated for those of which have allowMultiple flag set as false.
@@ -152,7 +153,8 @@ public class ProposalDevelopmentNarrativeRule extends KcTransactionalDocumentRul
             rulePassed = false;
         
         rulePassed &= validFileNameCharacters(narrative);
-        
+        rulePassed &= getKcFileService().validPDFFile(narrative, getErrorReporter(), ERROR_PREFIX_FOR_ATTACHMENTS);
+
         map.addToErrorPath(replaceNarrativeEvent.getErrorPathPrefix());
         rulePassed &= getDictionaryValidationService().isBusinessObjectValid(narrative);
         map.removeFromErrorPath(replaceNarrativeEvent.getErrorPathPrefix());

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/institute/ProposalDevelopmentInstituteAttachmentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/institute/ProposalDevelopmentInstituteAttachmentRule.java
@@ -113,13 +113,15 @@ public class ProposalDevelopmentInstituteAttachmentRule extends KcTransactionalD
         }
     
         rulePassed &= validFileNameCharacters(narrative, errorPath);
+        rulePassed &= getKcFileService().validPDFFile(narrative, getErrorReporter(), errorPath);
         
         return rulePassed;
-    }
+  }
     
     @Override
     public boolean processReplaceInstituteAttachmentBusinessRules(ReplaceInstituteAttachmentEvent event) {
-        return validFileNameCharacters(event.getNarrative(), event.getErrorPathPrefix());
+        return validFileNameCharacters(event.getNarrative(), event.getErrorPathPrefix()) &&
+               getKcFileService().validPDFFile(event.getNarrative(), getErrorReporter(), event.getErrorPathPrefix());
     }
     
     private boolean validFileNameCharacters(Narrative narrative, String errorPath) {
@@ -145,7 +147,7 @@ public class ProposalDevelopmentInstituteAttachmentRule extends KcTransactionalD
         
         return rulePassed;
     }
-    
+
     /**
      * 
      * This method is get narrative type reference which will be used to retrieve allow multiple indicator for rule checking.

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/attachment/ProposalDevelopmentPersonnelAttachmentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/attachment/ProposalDevelopmentPersonnelAttachmentRule.java
@@ -88,7 +88,7 @@ public class ProposalDevelopmentPersonnelAttachmentRule extends KcTransactionalD
         	}
         }
 
-        rulePassed &= checkForValidFileType(proposalPersonBiography);
+        rulePassed &= getKcAttachmentService().validPDFFile(proposalPersonBiography, getErrorReporter(), PERSONNEL_ATTACHMENT_FILE);
 
         if (!checkForProposalPerson(proposalPersonBiography)) {
             rulePassed = false;
@@ -106,7 +106,7 @@ public class ProposalDevelopmentPersonnelAttachmentRule extends KcTransactionalD
     @Override
     public boolean processReplacePersonnelAttachmentBusinessRules(ReplacePersonnelAttachmentEvent event) {
         boolean retVal = checkForInvalidCharacters(getKcAttachmentService().getInvalidCharacters(event.getProposalPersonBiography().getName()));
-        retVal &= checkForValidFileType(event.getProposalPersonBiography());
+        retVal &= getKcAttachmentService().validPDFFile(event.getProposalPersonBiography(), getErrorReporter(), PERSONNEL_ATTACHMENT_FILE);
         return retVal;
     }
 
@@ -132,7 +132,7 @@ public class ProposalDevelopmentPersonnelAttachmentRule extends KcTransactionalD
             }
         }
 
-        retVal &= checkForValidFileType(biography);
+        retVal &= getKcAttachmentService().validPDFFile(biography, getErrorReporter(), PERSONNEL_ATTACHMENT_FILE);
 
         if (!checkForDuplicates(biography,biographies)){
             retVal = false;
@@ -171,15 +171,6 @@ public class ProposalDevelopmentPersonnelAttachmentRule extends KcTransactionalD
             }
         }
         return rulePassed;
-    }
-
-    protected boolean checkForValidFileType(ProposalPersonBiography proposalPersonBiography) {
-        if (!Constants.PDF_REPORT_CONTENT_TYPE.equals(proposalPersonBiography.getContentType())) {
-            reportWarning(PERSONNEL_ATTACHMENT_FILE, KeyConstants.INVALID_FILE_TYPE,
-                    proposalPersonBiography.getName(), Constants.PDF_REPORT_CONTENT_TYPE);
-        }
-
-        return true;
     }
 
     protected boolean checkForInvalidCharacters(String invalidCharacters) {


### PR DESCRIPTION
Added a check to make sure file type was PDF. I also deleted an extra call to putWarning() because it resulted in duplicate warnings reported for invalid characters in file name.