### PR TITLE
KRACOEUS-8686

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentControllerBase.java
@@ -255,11 +255,12 @@ public abstract class ProposalDevelopmentControllerBase {
          ((ProposalDevelopmentViewHelperServiceImpl)form.getViewHelperService()).setOrdinalPosition(form.getDevelopmentProposal().getProposalPersons());
          saveAnswerHeaders(form, form.getPageId());
 
+         getTransactionalDocumentControllerService().save(form);
          if (form.isAuditActivated()){
              getAuditHelper().auditConditionally(form);
          }
 
-         getTransactionalDocumentControllerService().save(form);
+         
          populateAdHocRecipients(form.getProposalDevelopmentDocument());
 
          if (StringUtils.equalsIgnoreCase(form.getPageId(), Constants.CREDIT_ALLOCATION_PAGE)) {


### PR DESCRIPTION
Fix issue related to audit rules invoked and correspinding save in attachments
causing unique constraint violation.
Issue here is that on submit proposal, audit rules are invoked and if there are rules where we need to add additional attachments, we navigate to attachments page, add attachment and save is reinserting existing records causing unique constraint violation. 
While saving from narratives page, we retrieve the latest document from database and setting attachments to avoid concurrent modification issue. 
Not sure what is going on exactly here but looks like eclipse link is detaching the collection? and identifying it as new records and inserting
