### PR TITLE
KRACOEUS-8688

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocument.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentDocument.java
@@ -611,8 +611,8 @@ public class ProposalDevelopmentDocument extends BudgetParentDocument<Developmen
 
     @Override
     public List getNotes() {
-        if (CollectionUtils.isEmpty(notes)) {
-            notes = new ArrayList<>(super.getNotes());
+        if (StringUtils.isNotBlank(getNoteTarget().getObjectId())) {
+            notes = new ArrayList<>(getNoteService().getByRemoteObjectId(getNoteTarget().getObjectId()));
         }
         return notes;
     }


### PR DESCRIPTION
KRACOEUS-8688
Fix optimistic lock exception and duplicate notes
We are not dealing with the latest notes which is causing optimistic locking.
Also this fix deals with duplicate entries in notes.
