### PR TITLE
KRACOEUS-8668:hide super user actions on child proposals

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/auth/ProposalDevelopmentDocumentViewAuthorizer.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/auth/ProposalDevelopmentDocumentViewAuthorizer.java
@@ -65,6 +65,7 @@ public class ProposalDevelopmentDocumentViewAuthorizer extends KcKradTransaction
 	public Set<String> getActionFlags(View view, ViewModel model, Person user, Set<String> actions) {
 
 		Document document = ((DocumentFormBase) model).getDocument();
+        DevelopmentProposal developmentProposal = ((ProposalDevelopmentDocument)document).getDevelopmentProposal();
 
 		if (actions.contains(ProposalDevelopmentConstants.PropDevDocumentActions.SUBMIT_TO_SPONSOR) && ! canCreateInstitutionalProposal(document, user)) {
             actions.remove(ProposalDevelopmentConstants.PropDevDocumentActions.SUBMIT_TO_SPONSOR);
@@ -77,6 +78,19 @@ public class ProposalDevelopmentDocumentViewAuthorizer extends KcKradTransaction
         if (canNotifyProposalPerson(document,user)) {
             actions.add(ProposalDevelopmentConstants.PropDevDocumentActions.NOTIFY_PROPOSAL_PERSONS);
         }
+
+        if (actions.contains(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_APPROVE) && developmentProposal.isChild()) {
+            actions.remove(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_APPROVE);
+        }
+
+        if (actions.contains(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_DISAPPROVE) && developmentProposal.isChild()) {
+            actions.remove(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_DISAPPROVE);
+        }
+
+        if (actions.contains(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_TAKE_ACTION) && developmentProposal.isChild()) {
+            actions.remove(KRADConstants.KUALI_ACTION_CAN_SUPER_USER_TAKE_ACTION);
+        }
+
 		return super.getActionFlags(view, model, user, actions);
 	}
 

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/hierarchy/ProposalDevelopmentHierarchyController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/hierarchy/ProposalDevelopmentHierarchyController.java
@@ -141,6 +141,8 @@ public class ProposalDevelopmentHierarchyController extends ProposalDevelopmentC
             childProposal = getProposalHierarchyService().removeFromHierarchy(childProposal);
             form.getProposalDevelopmentDocument().setDevelopmentProposal(childProposal);
             displayMessage(ProposalHierarchyKeyConstants.MESSAGE_REMOVE_SUCCESS);
+            form.setEvaluateFlagsAndModes(true);
+            form.setCanEditView(null);
         }
 
         return getModelAndViewService().getModelAndView(form);

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalHierarchyPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/core/ProposalHierarchyPage.xml
@@ -59,9 +59,9 @@
 						<bean p:actionLabel="Link a Child to this Parent" parent="Uif-PrimaryActionButton" p:methodToCall="linkChildToHierarchy"
                               p:render="@{document.developmentProposal.isParent() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}" p:dialogDismissOption="REQUEST" 
                               p:order="10"/>
-                        <bean p:actionLabel="Link this Child to a Parent" parent="Uif-PrimaryActionButton" p:methodToCall="linkToHierarchy"
+                        <bean p:actionLabel="Link this Child to a Parent" parent="Uif-PrimaryActionButton" p:methodToCall="linkToHierarchy" p:ajaxSubmit="false"
                               p:render="@{!document.developmentProposal.isInHierarchy() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}" p:dialogDismissOption="REQUEST" p:order="20"/>
-						<bean p:actionLabel="Create Hierarchy" parent="Uif-SecondaryActionButton" p:methodToCall="createHierarchy"
+						<bean p:actionLabel="Create Hierarchy" parent="Uif-SecondaryActionButton" p:methodToCall="createHierarchy" p:ajaxSubmit="false"
                               p:render="@{!document.developmentProposal.isInHierarchy() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}" p:performClientSideValidation="true" p:dialogDismissOption="REQUEST" p:order="30"/>
                         <bean p:actionLabel="Sync Hierarchy" parent="Uif-SecondaryActionButton" p:methodToCall="syncToHierarchyParent"
                               p:render="@{document.developmentProposal.isChild() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}" p:performClientSideValidation="true" p:dialogDismissOption="REQUEST" p:order="40">
@@ -71,7 +71,7 @@
 								</list>
 							</property>
 						</bean>
-                        <bean p:actionLabel="Unlink Hierarchy" parent="Uif-SecondaryActionButton" p:methodToCall="removeFromHierarchy"
+                        <bean p:actionLabel="Unlink Hierarchy" parent="Uif-SecondaryActionButton" p:methodToCall="removeFromHierarchy" p:ajaxSubmit="false"
                               p:render="@{document.developmentProposal.isChild() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}" p:performClientSideValidation="true" p:dialogDismissOption="REQUEST" p:order="50"/>
                         <bean p:actionLabel="Sync All" parent="Uif-SecondaryActionButton" p:methodToCall="syncAllHierarchy"
                               p:render="@{document.developmentProposal.isParent() and #editModes[#proposalAuthConsts.MAINTAIN_HIERARCHY_EDIT_MODE]}"  p:performClientSideValidation="false" p:dialogDismissOption="REQUEST" p:order="60">


### PR DESCRIPTION
also updates permissions on unlink from hierarchy.  The non-ajax submits are needed to refresh the navigation menu to remove/add the super user navigation link.