### PR TITLE
KRACOEUS-8693 : Fix budget person salary details mapping

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPerson.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPerson.java
@@ -216,6 +216,7 @@ public class BudgetPerson extends KcPersistableBusinessObjectBase implements Per
       if ((this.budgetPersonSalaryDetails == null || this.budgetPersonSalaryDetails.isEmpty()) && getBudget() != null) {
           for (BudgetPeriod budgetPeriod : getBudget().getBudgetPeriods()) {
         	  BudgetPersonSalaryDetails budgetPersonSalaryDetails = new BudgetPersonSalaryDetails();
+        	  budgetPersonSalaryDetails.setBudgetPerson(this);
         	  budgetPersonSalaryDetails.setBudgetId(getBudgetId());
         	  budgetPersonSalaryDetails.setBudgetPeriod(budgetPeriod.getBudgetPeriod());
         	  budgetPersonSalaryDetails.setPersonId(getPersonId());

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPersonSalaryDetails.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPersonSalaryDetails.java
@@ -39,10 +39,10 @@ public class BudgetPersonSalaryDetails extends KcPersistableBusinessObjectBase {
     @Column(name = "BUDGET_PERSON_SALARY_DETAIL_ID")
     private Long budgetPersonSalaryDetailId;  
     
-    @Column(name = "PERSON_SEQUENCE_NUMBER")
+    @Column(name = "PERSON_SEQUENCE_NUMBER", insertable = false, updatable = false)
     private Integer personSequenceNumber;
     
-    @Column(name = "BUDGET_ID")
+    @Column(name = "BUDGET_ID", insertable = false, updatable = false)
     private Long budgetId;
     
     @Column(name = "BUDGET_PERIOD")
@@ -55,8 +55,8 @@ public class BudgetPersonSalaryDetails extends KcPersistableBusinessObjectBase {
     private ScaleTwoDecimal baseSalary = ScaleTwoDecimal.ZERO;
 
     @ManyToOne(cascade = { CascadeType.REFRESH })
-    @JoinColumns({ @JoinColumn(name = "BUDGET_ID", referencedColumnName = "BUDGET_ID", insertable = false, updatable = false), 
-    	@JoinColumn(name = "PERSON_SEQUENCE_NUMBER", referencedColumnName = "PERSON_SEQUENCE_NUMBER", insertable = false, updatable = false) })
+    @JoinColumns({ @JoinColumn(name = "BUDGET_ID", referencedColumnName = "BUDGET_ID"), 
+    	@JoinColumn(name = "PERSON_SEQUENCE_NUMBER", referencedColumnName = "PERSON_SEQUENCE_NUMBER") })
     private BudgetPerson budgetPerson;
 
     public Long getBudgetPersonSalaryDetailId() {

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/personnel/BudgetPersonnelBudgetServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/personnel/BudgetPersonnelBudgetServiceImpl.java
@@ -118,6 +118,7 @@ public class BudgetPersonnelBudgetServiceImpl implements BudgetPersonnelBudgetSe
             for (BudgetPeriod budgetPeriodData : budgetPeriodList) {
                 BudgetPersonSalaryDetails personSalaryDetails = new BudgetPersonSalaryDetails();
               
+                personSalaryDetails.setBudgetPerson(budgetPerson);;
                 personSalaryDetails.setBudgetId(budget.getBudgetId());
                 personSalaryDetails.setPersonSequenceNumber(budgetPerson.getPersonSequenceNumber());
                 personSalaryDetails.setBudgetPeriod(budgetPeriodData.getBudgetPeriod());

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/struts/BudgetPersonnelAction.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/struts/BudgetPersonnelAction.java
@@ -833,6 +833,7 @@ public class BudgetPersonnelAction extends BudgetExpensesAction {
             budgetPerSalaryDetails.setBudgetId(budget.getBudgetId());
             budgetPerSalaryDetails.setPersonSequenceNumber(budget.getBudgetPerson(getSelectedLine(request))
                     .getPersonSequenceNumber());
+            budgetPerSalaryDetails.setBudgetPerson(budget.getBudgetPerson(getSelectedLine(request)));
             if (budget.getBudgetPerson(getSelectedLine(request)).getPersonId() != null) {
                 budgetPerSalaryDetails.setPersonId(budget.getBudgetPerson(getSelectedLine(request)).getPersonId());
             } else if (budget.getBudgetPerson(getSelectedLine(request)).getRolodexId() != null) {


### PR DESCRIPTION
Looking at it now more work might need to be done related to these details during hierarchy sync to account for budget period shift. But I'm not sure how critical that is since I can't find anywhere they are used in the actual calculation. But this fixes the duplication of these items in the child budget when the link was based on the id instead of the parent BO. This missing link would cause duplication of all items during sync into the child.