### PR TITLE
KRACOEUS-8210 institute rate and institute LA fields editable and audit ...

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
@@ -273,6 +273,7 @@ public final class KeyConstants {
     public static final String ERROR_RATE_TYPE_NOT_EXIST = "error.rateType.not.exist";
     public static final String ERROR_RATE_TYPE_NOT_VALID_FOR_TYPE = "error.rateType.not.valid.for.type";
     public static final String ERROR_RATE_CLASS_NOT_VALID_FOR_TYPE = "error.rateClass.not.valid.for.type";
+    public static final String ERROR_INSTITUTE_RATE_DUPLICATION = "error.institute.rate.duplicate";
     
     public static final String ERROR_EFFECTIVE_DATE_OUT_OF_RANGE = "error.effective.date.out.of.range";
     

--- a/coeus-impl/src/main/resources/ApplicationResources.properties
+++ b/coeus-impl/src/main/resources/ApplicationResources.properties
@@ -553,6 +553,7 @@ error.rateType.not.exist=Rate Type ({0},{1}) does not exist.
 error.rateType.not.valid.for.type=The Rate Type Code {0} is not valid for this type of rate document.
 error.required.answer=Answer is required for Question {0} in group {1}.
 error.required.applicable.indirect.cost.rate=Rate is a mandatory field
+error.institute.rate.duplicate=The combination of fiscal year, campus flag, rate class, rate type, start date, and unit number already exist.
 error.required.applicableRate=Applicable Rate is a required field.
 error.required.contact.type=Contact Type is a mandatory field
 error.required.fiscal.year=Fiscal Year is a mandatory field

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteLaRate.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteLaRate.xml
@@ -22,6 +22,7 @@
         <ref bean="InstituteLaRate-unitNumber" />
         <ref bean="InstituteLaRate-instituteRate" />
         <ref bean="InstituteLaRate-versionNumber" />
+        <ref bean="InstituteLaRate-objectId" />
         <ref bean="InstituteLaRate-rateClass.description" />
         <ref bean="InstituteLaRate-rateType.description" />
       </list>
@@ -207,6 +208,12 @@
 
   <bean id="InstituteLaRate-versionNumber" parent="InstituteLaRate-versionNumber-parentBean"/>
   <bean id="InstituteLaRate-versionNumber-parentBean" abstract="true" parent="AttributeReferenceDummy-versionNumber"/>
+  
+  <bean id="InstituteLaRate-objectId" parent="InstituteLaRate-objectId-parentBean"/>
+  <bean id="InstituteLaRate-objectId-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="objectId" />
+  </bean>
+  
   <bean id="InstituteLaRate-rateClass.description" parent="InstituteLaRate-rateClass.description-parentBean" />
   <bean id="InstituteLaRate-rateClass.description-parentBean" abstract="true" parent="RateClass-description">
     <property name="name" value="rateClass.description" />
@@ -229,14 +236,15 @@
           <property name="numberOfColumns" value="1" />
           <property name="inquiryFields" >
             <list>
-              <bean parent="FieldDefinition" p:attributeName="fiscalYear" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="onOffCampusFlag" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="rateClassCode" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="rateTypeCode" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="startDate" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="unitNumber" p:forceInquiry="true"/>
+              <bean parent="FieldDefinition" p:attributeName="fiscalYear" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="onOffCampusFlag" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="rateClassCode" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="rateTypeCode" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="startDate" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="unitNumber" p:forceInquiry="false"/>
               <bean parent="FieldDefinition" p:attributeName="instituteRate"/>
               <bean parent="FieldDefinition" p:attributeName="active"/>
+              <bean parent="FieldDefinition" p:attributeName="objectId" p:forceInquiry="true"/>
             </list>
           </property>
         </bean>
@@ -262,6 +270,7 @@
               <bean p:propertyName="unitNumber" parent="Uif-DataField"/>
               <bean p:propertyName="instituteRate" parent="Uif-DataField"/>
               <bean p:propertyName="active" parent="Uif-DataField"/>
+              <bean p:propertyName="objectId" parent="Uif-DataField"/>
             </list>
           </property>
         </bean>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteLaRateMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteLaRateMaintenanceDocument.xml
@@ -12,12 +12,7 @@
     </property>
     <property name="lockingKeys">
       <list>
-        <value>fiscalYear</value>
-        <value>onOffCampusFlag</value>
-        <value>rateClassCode</value>
-        <value>rateTypeCode</value>
-        <value>startDate</value>
-        <value>unitNumber</value>
+        <value>objectId</value>
       </list>
     </property>
     <property name="allowsRecordDeletion" value="true" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteRate.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/rate/InstituteRate.xml
@@ -23,6 +23,7 @@
         <ref bean="InstituteRate-unitNumber" />
         <ref bean="InstituteRate-instituteRate" />
         <ref bean="InstituteRate-versionNumber" />
+        <ref bean="InstituteRate-objectId" />
         <ref bean="InstituteRate-activityType.description" />
         <ref bean="InstituteRate-rateClass.description" />
         <ref bean="InstituteRate-rateType.description" />
@@ -236,6 +237,11 @@
   <bean id="InstituteRate-activityType.description-parentBean" abstract="true" parent="ActivityType-description">
     <property name="name" value="activityType.description" />
   </bean>
+  
+  <bean id="InstituteRate-objectId" parent="InstituteRate-objectId-parentBean"/>
+  <bean id="InstituteRate-objectId-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="objectId" />
+  </bean>
 
   <bean id="InstituteRate-rateClass.description" parent="InstituteRate-rateClass.description-parentBean"/>
   <bean id="InstituteRate-rateClass.description-parentBean" abstract="true" parent="RateClass-description">
@@ -259,15 +265,16 @@
           <property name="numberOfColumns" value="1" />
           <property name="inquiryFields" >
             <list>
-              <bean parent="FieldDefinition" p:attributeName="activityTypeCode" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="fiscalYear" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="onOffCampusFlag" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="rateClassCode" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="rateTypeCode" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="startDate" p:forceInquiry="true"/>
-              <bean parent="FieldDefinition" p:attributeName="unitNumber" p:forceInquiry="true"/>
+              <bean parent="FieldDefinition" p:attributeName="activityTypeCode" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="fiscalYear" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="onOffCampusFlag" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="rateClassCode" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="rateTypeCode" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="startDate" p:forceInquiry="false"/>
+              <bean parent="FieldDefinition" p:attributeName="unitNumber" p:forceInquiry="false"/>
               <bean parent="FieldDefinition" p:attributeName="instituteRate"/>
               <bean parent="FieldDefinition" p:attributeName="active"/>
+              <bean parent="FieldDefinition" p:attributeName="objectId" p:forceInquiry="true"/>
             </list>
           </property>
         </bean>
@@ -294,6 +301,7 @@
               <bean p:propertyName="unitNumber" parent="Uif-DataField"/>
               <bean p:propertyName="instituteRate" parent="Uif-DataField"/>
               <bean p:propertyName="active" parent="Uif-DataField"/>
+              <bean p:propertyName="objectId" parent="Uif-DataField"/>
             </list>
           </property>
         </bean>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/repository-budget.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/budget/impl/repository-budget.xml
@@ -591,18 +591,18 @@
 
 	--></class-descriptor>
 	<class-descriptor class="org.kuali.coeus.common.budget.framework.rate.InstituteLaRate" table="INSTITUTE_LA_RATES">
-		<field-descriptor name="fiscalYear" column="FISCAL_YEAR" jdbc-type="CHAR" primarykey="true"/>
-		<field-descriptor name="onOffCampusFlag" column="ON_OFF_CAMPUS_FLAG" jdbc-type="CHAR" primarykey="true" conversion="org.kuali.kra.infrastructure.OjbOnOffCampusFlagFieldConversion"/>
-		<field-descriptor name="rateClassCode" column="RATE_CLASS_CODE" jdbc-type="VARCHAR" primarykey="true"/>
-		<field-descriptor name="rateTypeCode" column="RATE_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true"/>
-		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" primarykey="true"/>
-		<field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc-type="VARCHAR" primarykey="true"/>
+		<field-descriptor name="fiscalYear" column="FISCAL_YEAR" jdbc-type="CHAR" primarykey="false"/>
+		<field-descriptor name="onOffCampusFlag" column="ON_OFF_CAMPUS_FLAG" jdbc-type="CHAR" primarykey="false" conversion="org.kuali.kra.infrastructure.OjbOnOffCampusFlagFieldConversion"/>
+		<field-descriptor name="rateClassCode" column="RATE_CLASS_CODE" jdbc-type="VARCHAR" primarykey="false"/>
+		<field-descriptor name="rateTypeCode" column="RATE_TYPE_CODE" jdbc-type="VARCHAR" primarykey="false"/>
+		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" primarykey="false"/>
+		<field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc-type="VARCHAR" primarykey="false"/>
 		<field-descriptor name="instituteRate" column="RATE" jdbc-type="DECIMAL" conversion="org.kuali.coeus.sys.framework.persistence.OjbScaleTwoDecimalFieldConversion"/>
 		<field-descriptor name="active" column="ACTIVE_FLAG" jdbc-type="CHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP"/>
 		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR"/>
 		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
-		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" primarykey="true"/>
 		<reference-descriptor name="rateType" class-ref="org.kuali.coeus.common.budget.framework.rate.RateType" auto-retrieve="true" auto-update="none" auto-delete="none">
 			<foreignkey field-ref="rateClassCode"/> 
 			<foreignkey field-ref="rateTypeCode"/> 
@@ -616,19 +616,19 @@
 		
 	</class-descriptor>
 	<class-descriptor class="org.kuali.coeus.common.budget.framework.rate.InstituteRate" table="INSTITUTE_RATES">
-		<field-descriptor name="activityTypeCode" column="ACTIVITY_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true"/>
-		<field-descriptor name="fiscalYear" column="FISCAL_YEAR" jdbc-type="CHAR" primarykey="true"/>
-		<field-descriptor name="onOffCampusFlag" column="ON_OFF_CAMPUS_FLAG" jdbc-type="CHAR" primarykey="true" conversion="org.kuali.kra.infrastructure.OjbOnOffCampusFlagFieldConversion"/>
-		<field-descriptor name="rateClassCode" column="RATE_CLASS_CODE" jdbc-type="VARCHAR" primarykey="true"/>
-		<field-descriptor name="rateTypeCode" column="RATE_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true"/>
-		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" primarykey="true"/>
-		<field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc-type="VARCHAR" primarykey="true"/>
+		<field-descriptor name="activityTypeCode" column="ACTIVITY_TYPE_CODE" jdbc-type="VARCHAR" primarykey="false"/>
+		<field-descriptor name="fiscalYear" column="FISCAL_YEAR" jdbc-type="CHAR" primarykey="false"/>
+		<field-descriptor name="onOffCampusFlag" column="ON_OFF_CAMPUS_FLAG" jdbc-type="CHAR" primarykey="false" conversion="org.kuali.kra.infrastructure.OjbOnOffCampusFlagFieldConversion"/>
+		<field-descriptor name="rateClassCode" column="RATE_CLASS_CODE" jdbc-type="VARCHAR" primarykey="false"/>
+		<field-descriptor name="rateTypeCode" column="RATE_TYPE_CODE" jdbc-type="VARCHAR" primarykey="false"/>
+		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" primarykey="false"/>
+		<field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc-type="VARCHAR" primarykey="false"/>
 		<field-descriptor name="instituteRate" column="RATE" jdbc-type="DECIMAL" conversion="org.kuali.coeus.sys.framework.persistence.OjbScaleTwoDecimalFieldConversion"/>
 		<field-descriptor name="active" column="ACTIVE_FLAG" jdbc-type="CHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP"/>
 		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR"/>
 		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
-		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" primarykey="true" />
 		<reference-descriptor name="rateType" class-ref="org.kuali.coeus.common.budget.framework.rate.RateType" auto-retrieve="true" auto-update="none" auto-delete="none">
 			<foreignkey field-ref="rateClassCode"/> 
 			<foreignkey field-ref="rateTypeCode"/> 

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/docs/InstituteRateMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/docs/InstituteRateMaintenanceDocument.xml
@@ -12,13 +12,7 @@
     </property>
     <property name="lockingKeys">
       <list>
-        <value>activityTypeCode</value>
-        <value>fiscalYear</value>
-        <value>onOffCampusFlag</value>
-        <value>rateClassCode</value>
-        <value>rateTypeCode</value>
-        <value>startDate</value>
-        <value>unitNumber</value>
+      	<value>objectId</value>
       </list>
     </property>
     <property name="preserveLockingKeysOnCopy" value="true" />


### PR DESCRIPTION
...rules now prevent duplicates

in the DD and repository.xml I switched objectId to be the PK and removed the composite fields as the PK so the fields could be editable.  However, the database still has the composite fields as the PK.  I added objectId to the inquiry as it needs a unique field to work.  I took this path to avoid adding an extra field.  The approach also doesn't seem to create the problems Chuck had in budget finding the updates.  (Sync rates seems to work fine after an update happens)