### PR TITLE
KRACOEUS-8301

### DIFF
--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/supplemental/ProposalSupplementalPage.xml
@@ -64,8 +64,9 @@
         <property name="items">
             <list>
                 <bean parent="Uif-InputField" class="org.kuali.coeus.propdev.impl.custom.ProposalDevelopmentCustomDataField"
-                      p:fieldLabel.labelText="@{#line.customAttribute ne null ? #line.customAttribute.label : &quot;Custom Attribute&quot;}"
-                      p:propertyName="value" p:required = "@{#ViewHelper.isRequired(#line.customAttribute, document.customDataList)}">
+                      p:fieldLabel.labelText="@{#line.customAttribute ne null ? #line.customAttribute.label : &quot;Custom Attribute&quot;}@{#ViewHelper.isRequired(#line.customAttribute, document.customDataList) ? ': [color=red]*[/color]' : ':'}"
+                      p:fieldLabel.renderColon="false"
+                      p:propertyName="value">
                     <property name="suggest">
                         <bean parent="Uif-Suggest" p:render="false" />
                     </property>


### PR DESCRIPTION
KRACOEUS-8301
Required fields in custom data is preventing from navigating away from
supplemental information page.

I did not see an option to add indicator as suffix to label.
Tried to turn on the renderRequiredIndicator for label and did not have any effect.

I don't understand why we need that required indicator here. I just added it to be inline with 5.2.1
Supplemental informations are validated as part of audit rules.
 