### PR TITLE
[KRACOEUS-7230] Re-implementing 5.2.1 QuestionResolver changes in KC 6.x

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/ProposalDevelopmentFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/ProposalDevelopmentFactBuilderServiceImpl.java
@@ -69,7 +69,7 @@ public class ProposalDevelopmentFactBuilderServiceImpl extends KcKrmsFactBuilder
         addProposalFacts(factsBuilder,developmentProposal);
         factsBuilder.addFact("moduleCode", CoeusModule.PROPOSAL_DEVELOPMENT_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", developmentProposal.getProposalNumber());
-        
+        factsBuilder.addFact("moduleSubItemKey", new Integer(0));
     }
     
     private void addBudgetFacts(Builder factsBuilder, ProposalDevelopmentDocument proposalDevelopmentDocument) {

--- a/coeus-impl/src/main/java/org/kuali/kra/award/AwardFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/AwardFactBuilderServiceImpl.java
@@ -59,6 +59,7 @@ public class AwardFactBuilderServiceImpl extends KcKrmsFactBuilderServiceHelper 
         // Questionnaire Prereqs
         factsBuilder.addFact("moduleCode", CoeusModule.AWARD_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", award.getAwardNumber());
+        factsBuilder.addFact("moduleSubItemKey", award.getSequenceNumber());
     }
     
     protected String getElementValue(String docContent, String xpathExpression) {

--- a/coeus-impl/src/main/java/org/kuali/kra/coi/CoiDisclosureFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/coi/CoiDisclosureFactBuilderServiceImpl.java
@@ -65,6 +65,7 @@ public class CoiDisclosureFactBuilderServiceImpl extends KcKrmsFactBuilderServic
         // Questionnaire Prereqs
         factsBuilder.addFact("moduleCode", CoeusModule.COI_DISCLOSURE_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", coiDisclosure.getCoiDisclosureNumber());
+        factsBuilder.addFact("moduleSubItemKey", coiDisclosure.getSequenceNumber());
     }
     
     protected String getElementValue(String docContent, String xpathExpression) {

--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocolFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocolFactBuilderServiceImpl.java
@@ -49,6 +49,7 @@ public class IacucProtocolFactBuilderServiceImpl extends KcKrmsFactBuilderServic
         factsBuilder.addFact(KcKrmsConstants.IacucProtocol.IACUC_PROTOCOL, protocol);
         factsBuilder.addFact("moduleCode", CoeusModule.IACUC_PROTOCOL_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", protocol.getProtocolNumber());
+        factsBuilder.addFact("moduleSubItemKey", protocol.getSequenceNumber());
     }
 
     /**

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalFactBuilderServiceImpl.java
@@ -49,7 +49,7 @@ public class InstitutionalProposalFactBuilderServiceImpl extends KcKrmsFactBuild
         addProposalFacts(factsBuilder,institutionalProposal);
         factsBuilder.addFact("moduleCode", CoeusModule.INSTITUTIONAL_PROPOSAL_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", institutionalProposal.getProposalNumber());
-        
+        factsBuilder.addFact("moduleSubItemKey", institutionalProposal.getSequenceNumber());
     }
     
     private void addProposalFacts(Builder factsBuilder, InstitutionalProposal institutionalProposal) {

--- a/coeus-impl/src/main/java/org/kuali/kra/irb/IrbProtocolFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/irb/IrbProtocolFactBuilderServiceImpl.java
@@ -49,6 +49,7 @@ public class IrbProtocolFactBuilderServiceImpl extends KcKrmsFactBuilderServiceH
         factsBuilder.addFact(KcKrmsConstants.IrbProtocol.IRB_PROTOCOL, protocol);
         factsBuilder.addFact("moduleCode", CoeusModule.IRB_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", protocol.getProtocolNumber());
+        factsBuilder.addFact("moduleSubItemKey", protocol.getSequenceNumber());
     }
 
     /**


### PR DESCRIPTION
KRACOEUS-7230 made some changes to the QuestionResolver so that it would match Question Term Parameters to Questions based on Question ID and Questionnaire ID instead of Question ID and Questionnaire Ref ID. Those changes were included in KC 5.2.1, but it looks like they didn't make it into 6.0. This commit reimplements those changes, as well as a few other improvements/bug fixes (use sequence number when retrieving answer headers, only use latest version of questionnaires for answer resolution).

This code also requires the following SQL to update Question Term Param names to the new "Seq ID" format:
```
update KRMS_TERM_RSLVR_PARM_SPEC_T set nm = 'Question Seq ID' where nm = 'Question ID';
update KRMS_TERM_RSLVR_PARM_SPEC_T set nm = 'Questionnaire Seq ID' where nm = 'Questionnaire ID';
update KRMS_TERM_PARM_T set nm = 'Question Seq ID' where nm = 'Question ID';
update KRMS_TERM_PARM_T set nm = 'Questionnaire Seq ID' where nm = 'Questionnaire ID';
```

I wasn't sure where the best place for this was, since all the upgrade scripts except for 6.0.1 seem to have been removed from the Kuali Github repo. This could be an upgrade script, or the parameter names referenced in the QuestionResolver class could be changed to "Questionnaire ID" and "Question ID" to avoid needing any SQL changes at all.