### PR TITLE
[KRACOEUS-7230] Re-implementing 5.2.1 QuestionResolver changes in KC 6.x

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/ProposalDevelopmentFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/ProposalDevelopmentFactBuilderServiceImpl.java
@@ -69,7 +69,7 @@ public class ProposalDevelopmentFactBuilderServiceImpl extends KcKrmsFactBuilder
         addProposalFacts(factsBuilder,developmentProposal);
         factsBuilder.addFact("moduleCode", CoeusModule.PROPOSAL_DEVELOPMENT_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", developmentProposal.getProposalNumber());
-        
+        factsBuilder.addFact("moduleSubItemKey", new Integer(0));
     }
     
     private void addBudgetFacts(Builder factsBuilder, ProposalDevelopmentDocument proposalDevelopmentDocument) {

--- a/coeus-impl/src/main/java/org/kuali/kra/award/AwardFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/AwardFactBuilderServiceImpl.java
@@ -59,6 +59,7 @@ public class AwardFactBuilderServiceImpl extends KcKrmsFactBuilderServiceHelper 
         // Questionnaire Prereqs
         factsBuilder.addFact("moduleCode", CoeusModule.AWARD_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", award.getAwardNumber());
+        factsBuilder.addFact("moduleSubItemKey", award.getSequenceNumber());
     }
     
     protected String getElementValue(String docContent, String xpathExpression) {

--- a/coeus-impl/src/main/java/org/kuali/kra/coi/CoiDisclosureFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/coi/CoiDisclosureFactBuilderServiceImpl.java
@@ -65,6 +65,7 @@ public class CoiDisclosureFactBuilderServiceImpl extends KcKrmsFactBuilderServic
         // Questionnaire Prereqs
         factsBuilder.addFact("moduleCode", CoeusModule.COI_DISCLOSURE_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", coiDisclosure.getCoiDisclosureNumber());
+        factsBuilder.addFact("moduleSubItemKey", coiDisclosure.getSequenceNumber());
     }
     
     protected String getElementValue(String docContent, String xpathExpression) {

--- a/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocolFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/iacuc/IacucProtocolFactBuilderServiceImpl.java
@@ -49,6 +49,7 @@ public class IacucProtocolFactBuilderServiceImpl extends KcKrmsFactBuilderServic
         factsBuilder.addFact(KcKrmsConstants.IacucProtocol.IACUC_PROTOCOL, protocol);
         factsBuilder.addFact("moduleCode", CoeusModule.IACUC_PROTOCOL_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", protocol.getProtocolNumber());
+        factsBuilder.addFact("moduleSubItemKey", protocol.getSequenceNumber());
     }
 
     /**

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalFactBuilderServiceImpl.java
@@ -49,7 +49,7 @@ public class InstitutionalProposalFactBuilderServiceImpl extends KcKrmsFactBuild
         addProposalFacts(factsBuilder,institutionalProposal);
         factsBuilder.addFact("moduleCode", CoeusModule.INSTITUTIONAL_PROPOSAL_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", institutionalProposal.getProposalNumber());
-        
+        factsBuilder.addFact("moduleSubItemKey", institutionalProposal.getSequenceNumber());
     }
     
     private void addProposalFacts(Builder factsBuilder, InstitutionalProposal institutionalProposal) {

--- a/coeus-impl/src/main/java/org/kuali/kra/irb/IrbProtocolFactBuilderServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/irb/IrbProtocolFactBuilderServiceImpl.java
@@ -49,6 +49,7 @@ public class IrbProtocolFactBuilderServiceImpl extends KcKrmsFactBuilderServiceH
         factsBuilder.addFact(KcKrmsConstants.IrbProtocol.IRB_PROTOCOL, protocol);
         factsBuilder.addFact("moduleCode", CoeusModule.IRB_MODULE_CODE);
         factsBuilder.addFact("moduleItemKey", protocol.getProtocolNumber());
+        factsBuilder.addFact("moduleSubItemKey", protocol.getSequenceNumber());
     }
 
     /**


### PR DESCRIPTION
KRACOEUS-7230

This re-implements some changes to the QuestionResolver code that we contributed before, and which made it into KC 5.2.1 but seem to have been left out of KC 6.0. It also includes a couple of our additional improvements/fixes to the QuestionResolver functionality, such as using the module sub item key when retrieving Answer Headers, filtering retrieved Answer Headers to only include those for the latest versions of Questionnaires, and making sure the Question Seq Id comparison is properly comparing String values. 

Please note that since the existing KRMS Question terms use "Question ID" and "Questionnaire ID" as parameters, the following SQL will need to be run to update them to the new "Seq ID" terminology:

```
update KRMS_TERM_RSLVR_PARM_SPEC_T set nm = 'Question Seq ID' where nm = 'Question ID';
update KRMS_TERM_RSLVR_PARM_SPEC_T set nm = 'Questionnaire Seq ID' where nm = 'Questionnaire ID';
update KRMS_TERM_PARM_T set nm = 'Question Seq ID' where nm = 'Question ID';
update KRMS_TERM_PARM_T set nm = 'Questionnaire Seq ID' where nm = 'Questionnaire ID';
``` 

Alternatively, the parameter names that QuestionResolver looks for could be changed to "Questionnaire ID" and "Question ID" to avoid the need for any SQL. 