### PR TITLE
[KRAFDBCK-10749] Escaping custom data values so single quotes don't term...

### DIFF
--- a/coeus-webapp/src/main/webapp/WEB-INF/tags/customdata/customData.tag
+++ b/coeus-webapp/src/main/webapp/WEB-INF/tags/customdata/customData.tag
@@ -85,7 +85,7 @@
                 	</c:when>
                 	<c:otherwise>
                 		${kfunc:registerEditableProperty(KualiForm, customAttributeId)}
-                		<input size="60" id="${customAttributeId}" type="text" name="${customAttributeId}" value='${customAttributeValue}' style="${customAttributeErrorStyle}"/>
+                        <input size="60" id="${customAttributeId}" type="text" name="${customAttributeId}" value='${fn:escapeXml(customAttributeValue)}' style="${customAttributeErrorStyle}"/>
 
 						<c:if test="${not empty customAttributeDocument.customAttribute.lookupClass}">
 						 <c:choose>


### PR DESCRIPTION
...inate them early.

This fixes being able to break out of custom data values with single quotes in the KNS custom data tag (KRAD does this already).