### PR TITLE
[KRAFDBCK-12440] New parameter to hide Intellectual Property Review tab in IP

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
@@ -457,7 +457,9 @@ public interface Constants {
     public static final String MAPPING_INSTITUTIONAL_PROPOSAL_DISTRIBUTION_PAGE = "distribution";
     public static final String MAPPING_INSTITUTIONAL_PROPOSAL_ACTIONS_PAGE = "institutionalProposalActions";
     public static final String MAPPING_INSTITUTIONAL_PROPOSAL_MEDUSA_PAGE = "medusa";
-    
+
+    public static final String PARAMETER_IP_REVIEW_TAB_ENABLED = "IP_INTELLECTUAL_PROPERTY_REVIEW_TAB_ENABLED";
+
     public static final String INSTITUTIONAL_PROPSAL_PROPSAL_NUMBER_SEQUENCE = "SEQ_PROPOSAL_PROPOSAL_ID";
     
     public static final String COST_SHARE_COMMENT_TYPE_CODE = "9";

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/web/struts/form/InstitutionalProposalForm.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/web/struts/form/InstitutionalProposalForm.java
@@ -466,16 +466,30 @@ public class InstitutionalProposalForm extends KcTransactionalDocumentFormBase i
                 if (displayTab) {
                     resultList.add(nav);
                 }
-            } else {
+            } else if (StringUtils.equals(nav.getHeaderTabNavigateTo(), Constants.MAPPING_INSTITUTIONAL_PROPOSAL_INTELLECTUAL_PROPERTY_REVIEW_PAGE)) {
+                if (isIPReviewTabEnabled()) {
+                    resultList.add(nav);
+                }
+            }
+            else {
                 resultList.add(nav);
             }
         }
-        
+
         HeaderNavigation[] result = new HeaderNavigation[resultList.size()];
         resultList.toArray(result);
         return result;
     }
-    
+
+    public boolean isIPReviewTabEnabled() {
+        Boolean ipReviewTabEnabled = getParameterService().getParameterValueAsBoolean(Constants.MODULE_NAMESPACE_INSITUTIONAL_PROPOSAL,
+                Constants.PARAMETER_COMPONENT_DOCUMENT, Constants.PARAMETER_IP_REVIEW_TAB_ENABLED);
+        if (ipReviewTabEnabled != null) {
+            return ipReviewTabEnabled;
+        }
+        return true;
+    }
+
     public List<ExtraButton> getExtraActionsButtons() {
         extraButtons.clear();
         


### PR DESCRIPTION
KRAFDBCK-12440
This enhancement adds a new parameter "IP_INTELLECTUAL_PROPERTY_REVIEW_TAB_ENABLED" to determine whether or not the Intellectual Property Review tab should be shown in IP. If the parameter doesn't exist, then it defaults to showing the tab. 

Here is the SQL to add the new parameter: 

```
INSERT INTO KRCR_PARM_T (NMSPC_CD, CMPNT_CD, PARM_NM, OBJ_ID, VER_NBR, PARM_TYP_CD, VAL, PARM_DESC_TXT, EVAL_OPRTR_CD, APPL_ID)
VALUES ('KC-IP', 'Document', 'IP_INTELLECTUAL_PROPERTY_REVIEW_TAB_ENABLED', SYS_GUID(), 1, 'CONFG', 'Y', 'This param can be used to turn the Intellectual Property Review tab on/off in Institutional Propsoal', 'A', 'KC');
```

I'm still not sure what the best way to handle the SQL portion of our contributions, so please let me know what your preference is (aka adding a new folder to the coeus-db-sql module, or just including it in the PR so you can put it wherever you want).