### PR TITLE
[KRAFDBCK-10952] Adding ability to send Award Notice Notifications

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V603_001__KRAFDBCK-10952.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V603_001__KRAFDBCK-10952.sql
@@ -1,0 +1,28 @@
+insert into notification_type (notification_type_id, module_code, action_code, description, subject, message, prompt_user, send_notification, update_user, update_timestamp, ver_nbr, obj_id)
+  values ((select (max(id)) from seq_notification_type_id), 1, '556', 'Award Notice', 'Award Notice for Award {AWARD_NUMBER}',
+          'The Award Notice for Award {AWARD_NUMBER} is available for printing: <a title="" target="_self" href="{DOCUMENT_PREFIX}/awardActions.do?methodToCall=printNoticeFromNotification&amp;awardNoticeId={AWARD_NOTICE_ID}"><img src="{DOCUMENT_PREFIX}/static/images/tinybutton-print.gif" alt="Print Award Notice for Award {AWARD_NUMBER}"></a>',
+          'N', 'Y', 'kc', now(), 1, uuid());
+insert into seq_notification_type_id values (null);
+
+-- Award Notice Recipient Role
+insert into notification_type_recipient (notification_type_recipient_id, notification_type_id, role_name, update_user, update_timestamp, ver_nbr, obj_id)
+  values ((select (max(id)) from seq_notification_type_id), (select notification_type_id from notification_type where module_code = '1' and action_code = '556'), 'KC-AWARD:Investigators', 'kc', now(), 1, uuid());
+insert into seq_notification_type_id values (null);
+
+insert into notification_type_recipient (notification_type_recipient_id, notification_type_id, role_name, update_user, update_timestamp, ver_nbr, obj_id)
+  values ((select (max(id)) from seq_notification_type_id), (select notification_type_id from notification_type where module_code = '1' and action_code = '556'), 'KC-AWARD:All Unit Administrators', 'kc', now(), 1, uuid());
+insert into seq_notification_type_id values (null);
+
+create table award_notice (
+  award_notice_id decimal(22, 0) not null,
+  award_id decimal(22, 0) not null,
+  award_number varchar(12),
+  unit_number varchar(8),
+  pdf_content longtext,
+  constraint award_noticep1 primary key (award_notice_id)
+) engine InnoDB character set utf8 collate utf8_bin;
+
+create table seq_award_notice_id (
+  id bigint(19) not null auto_increment, primary key (id)
+) engine MyISAM;
+alter table seq_award_notice_id auto_increment = 1;

--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/kc/6_0_3.bootstrap/V603_001__KRAFDBCK-10952.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/kc/6_0_3.bootstrap/V603_001__KRAFDBCK-10952.sql
@@ -1,0 +1,27 @@
+set define off;
+
+insert into notification_type (notification_type_id, module_code, action_code, description, subject, message, prompt_user, send_notification, update_user, update_timestamp, ver_nbr, obj_id)
+  values (seq_notification_type_id.nextval, 1, '556', 'Award Notice', 'Award Notice for Award {AWARD_NUMBER}',
+          'The Award Notice for Award {AWARD_NUMBER} is available for printing: <a title="" target="_self" href="{DOCUMENT_PREFIX}/awardActions.do?methodToCall=printNoticeFromNotification&amp;awardNoticeId={AWARD_NOTICE_ID}"><img src="{DOCUMENT_PREFIX}/static/images/tinybutton-print.gif" alt="Print Award Notice for Award {AWARD_NUMBER}"></a>',
+          'N', 'Y', 'kc', current_timestamp, 1, sys_guid());
+
+-- Award Notice Recipient Role
+insert into notification_type_recipient (notification_type_recipient_id, notification_type_id, role_name, update_user, update_timestamp, ver_nbr, obj_id)
+  values (seq_notification_type_id.nextval, (select notification_type_id from notification_type where module_code = '1' and action_code = '556'), 'KC-AWARD:Investigators', 'kc', current_timestamp, 1, sys_guid());
+
+insert into notification_type_recipient (notification_type_recipient_id, notification_type_id, role_name, update_user, update_timestamp, ver_nbr, obj_id)
+  values (seq_notification_type_id.nextval, (select notification_type_id from notification_type where module_code = '1' and action_code = '556'), 'KC-AWARD:All Unit Administrators', 'kc', current_timestamp, 1, sys_guid());
+
+create table award_notice (
+  award_notice_id number(22) not null primary key,
+  award_id number(22) not null,
+  award_number varchar(13),
+  unit_number varchar(8),
+  pdf_content clob
+);
+
+create sequence SEQ_AWARD_NOTICE_ID
+  minvalue 1
+  start with 1
+  increment by 1
+  nocache;

--- a/coeus-impl/src/main/java/org/kuali/kra/award/notification/AwardNoticeNotificationRenderer.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/notification/AwardNoticeNotificationRenderer.java
@@ -1,0 +1,58 @@
+package org.kuali.kra.award.notification;
+
+import org.kuali.coeus.common.notification.impl.NotificationRendererBase;
+import org.kuali.rice.core.api.CoreApiServiceLocator;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AwardNoticeNotificationRenderer extends NotificationRendererBase {
+
+    private static final long serialVersionUID = -2831418548566311094L;
+
+    private static final String DOCHANDLER_APP_URL_PROP = "application.url";
+
+    public static final String AWARD_NOTICE_ID = "{AWARD_NOTICE_ID}";
+    public static final String AWARD_NUMBER = "{AWARD_NUMBER}";
+    public static final String DOCHANDLER_PREFIX = "{DOCUMENT_PREFIX}";
+
+    protected Long awardNoticeId;
+    protected String awardNumber;
+
+    private ConfigurationService kualiConfigurationService;
+
+    public AwardNoticeNotificationRenderer(Long awardNoticeId, String awardNumber) {
+        this.awardNoticeId = awardNoticeId;
+        this.awardNumber = awardNumber;
+    }
+
+    @Override
+    public Map<String,String> getDefaultReplacementParameters() {
+        Map<String,String> replacementParams = new HashMap<String,String>();
+        replacementParams.put(AWARD_NOTICE_ID, awardNoticeId.toString());
+        replacementParams.put(AWARD_NUMBER, awardNumber);
+        replacementParams.put(DOCHANDLER_PREFIX, getDocumentLocation());
+
+        return replacementParams;
+    }
+
+    // Overriding this method since NotificationRendererBase doesn't form the URL correctly
+    protected String getDocumentLocation() {
+        String result = null;
+        String appUrl = getKualiConfigurationService().getPropertyValueAsString(DOCHANDLER_APP_URL_PROP);
+        if (appUrl == null) {
+            result = "..";   // default is to back up URL before KEN (relative to base at this server)
+        } else {
+            result = appUrl;
+        }
+        return result;
+    }
+
+    protected ConfigurationService getKualiConfigurationService() {
+        if (kualiConfigurationService == null) {
+            kualiConfigurationService = CoreApiServiceLocator.getKualiConfigurationService();
+        }
+        return kualiConfigurationService;
+    }
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/award/notification/AwardNoticePrintout.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/notification/AwardNoticePrintout.java
@@ -1,0 +1,84 @@
+package org.kuali.kra.award.notification;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.kuali.coeus.sys.framework.model.KcPersistableBusinessObjectBase;
+
+public class AwardNoticePrintout extends KcPersistableBusinessObjectBase {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long awardNoticeId;
+    private Long awardId;
+    private String awardNumber;
+    private String accountNumber;
+    private String unitNumber;
+    private String pdfContent;
+
+    public AwardNoticePrintout() {
+        super();
+    }
+
+    public AwardNoticePrintout(Long awardId, String awardNumber, String accountNumber) {
+        this();
+        this.awardId = awardId;
+        this.awardNumber = awardNumber;
+        this.accountNumber = accountNumber;
+    }
+
+    public AwardNoticePrintout(Long awardId, String awardNumber, String accountNumber, String unitNumber) {
+        this();
+        this.awardId = awardId;
+        this.awardNumber = awardNumber;
+        this.accountNumber = accountNumber;
+        this.unitNumber = unitNumber;
+    }
+
+    public Long getAwardNoticeId() {
+        return awardNoticeId;
+    }
+
+    public void setAwardNoticeId(Long awardNoticeId) {
+        this.awardNoticeId = awardNoticeId;
+    }
+
+    public Long getAwardId() {
+        return awardId;
+    }
+
+    public void setAwardId(Long awardId) {
+        this.awardId = awardId;
+    }
+
+    public String getAwardNumber() {
+        return awardNumber;
+    }
+
+    public void setAwardNumber(String awardNumber) {
+        this.awardNumber = awardNumber;
+    }
+
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    public void setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public String getUnitNumber() {
+        return unitNumber;
+    }
+
+    public void setUnitNumber(String unitNumber) {
+        this.unitNumber = unitNumber;
+    }
+
+    public byte[] getPdfContent() throws DecoderException {
+        return Hex.decodeHex(pdfContent.toCharArray());
+    }
+
+    public void setPdfContent(byte[] pdfContent) {
+        this.pdfContent = Hex.encodeHexString(pdfContent);
+    }
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/Constants.java
@@ -410,6 +410,7 @@ public interface Constants {
     public static final String MAPPING_AWARD_ACTIONS_PAGE = "awardActions";
     public static final String MAPPING_AWARD_MEDUSA_PAGE = "medusa";
     public static final String MAPPING_AWARD_BUDGET_VERSIONS_PAGE = "budgets";
+    public static final String MAPPING_AWARD_NOTIFICATION_EDITOR = "notificationEditor";
     public static final String MAPPING_ICR_RATE_CODE_PROMPT = "icrRateCodePrompt";
     
     

--- a/coeus-impl/src/main/resources/org/kuali/kra/award/repository-award.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/award/repository-award.xml
@@ -1595,8 +1595,14 @@
 		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
     	
     </class-descriptor>
-    
-	
+
+	<class-descriptor class="org.kuali.kra.award.notification.AwardNoticePrintout" table="AWARD_NOTICE">
+		<field-descriptor name="awardNoticeId" column="AWARD_NOTICE_ID" jdbc-type="BIGINT" primarykey="true" autoincrement="true" sequence-name="SEQ_AWARD_NOTICE_ID" />
+		<field-descriptor name="awardId" column="AWARD_ID" jdbc_type="BIGINT"/>
+		<field-descriptor name="awardNumber" column="AWARD_NUMBER" jdbc_type="VARCHAR"/>
+		<field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc_type="VARCHAR"/>
+		<field-descriptor name="pdfContent" column="PDF_CONTENT" jdbc_type="CLOB"/>
+	</class-descriptor>
 	
 	<class-descriptor class="org.kuali.kra.award.subcontracting.goalsAndExpenditures.AwardSubcontractingBudgetedGoals" table="SUBCONTRACTING_BUD">
 		<field-descriptor name="awardNumber" column="AWARD_NUMBER" jdbc-type="VARCHAR" primarykey="true" />

--- a/coeus-webapp/src/main/webapp/WEB-INF/tags/award/awardPrint.tag
+++ b/coeus-webapp/src/main/webapp/WEB-INF/tags/award/awardPrint.tag
@@ -150,9 +150,15 @@
       			  </div>  
       			 </div>
 				</td>
-				<td class="infoline" style="text-align:center;"><html:image property="methodToCall.printNotice"
-						src='${ConfigProperties.kra.externalizable.images.url}tinybutton-print.gif' 
-						alt="Print Award Notice" styleClass="tinybutton" onclick="excludeSubmitRestriction=true"/></td>
+				<td class="infoline" style="text-align:center;">
+					<div><html:image property="methodToCall.printNotice"
+									 src='${ConfigProperties.kra.externalizable.images.url}tinybutton-print.gif'
+									 alt="Print Award Summary" styleClass="tinybutton" onclick="excludeSubmitRestriction=true"/></div>
+					<div style="padding-top: 10px;">
+						<html:image property="methodToCall.sendNotice"
+									src='${ConfigProperties.kr.externalizable.images.url}tinybutton-send.gif'
+									alt="Send Award Summary" styleClass="tinybutton" onclick="excludeSubmitRestriction=true"/></div>
+				</td>
 			</tr><tr> 
 				<th scope="row" style="width:150px; text-align: left;">Award Modification</th>
 				 <td style="padding: 5px;">


### PR DESCRIPTION
KRAFDBCK-10952
Added new notification type and logic for sending Award Notices from the print tab of the Award Actions page. This contribution also adds a new AWARD_NOTICE table to store persisted Notice PDFs, so that they can be easily retrieved from the notification recipients' Action List later.

I included the required SQL in both Oracle and MySQL dialects as V603_001__KRAFDBCK-10952.sql files in the respective coeus-db/.../data/migration/... folders, but as always, just let me know if there's another convention you'd like me to follow.