### PR TITLE
[#RESSUP-1385] Added 'Document Status' field to Award lookup and results

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/dao/ojb/AwardLookupDaoOjb.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/dao/ojb/AwardLookupDaoOjb.java
@@ -18,20 +18,28 @@
  */
 package org.kuali.kra.award.dao.ojb;
 
+import org.apache.ojb.broker.PersistenceBroker;
+import org.apache.ojb.broker.accesslayer.LookupException;
 import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryByCriteria;
 import org.apache.ojb.broker.query.QueryFactory;
 import org.kuali.coeus.common.framework.version.VersionStatus;
 import org.kuali.coeus.common.impl.version.history.VersionHistoryLookupDao;
-import org.kuali.kra.award.home.Award;
 import org.kuali.kra.award.dao.AwardLookupDao;
+import org.kuali.kra.award.home.Award;
 import org.kuali.kra.timeandmoney.document.TimeAndMoneyDocument;
 import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kew.api.WorkflowRuntimeException;
 import org.kuali.rice.krad.bo.BusinessObject;
 import org.kuali.rice.krad.bo.DocumentHeader;
 import org.kuali.rice.krad.dao.impl.LookupDaoOjb;
 import org.kuali.rice.krad.lookup.CollectionIncomplete;
+import org.springmodules.orm.ojb.OjbFactoryUtils;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,21 +47,59 @@ import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class AwardLookupDaoOjb extends LookupDaoOjb  implements AwardLookupDao{
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AwardLookupDaoOjb.class);
+
+    private static final String ACTIVE_AWARD_SEQUENCE_STATUS  = "ACTIVE";  // Final
+    private static final String PENDING_AWARD_SEQUENCE_STATUS = "PENDING"; // Saved
+    private static final String ACTIVE_OR_PENDING_AWARD_SEQUENCE_STATUS = "ACTIVE|PENDING";
+    private static final String BOTH_AWARD_SEQUENCE_STATUS = "BOTH";
+
     private VersionHistoryLookupDao versionHistoryLookupDao;
 
     @SuppressWarnings("rawtypes")
     @Override
     public List<? extends BusinessObject> getAwardSearchResults(Map fieldValues, boolean usePrimaryKeys) {
+        if (fieldValues.containsKey("awardSequenceStatus") &&
+                fieldValues.get("awardSequenceStatus").toString().equalsIgnoreCase(BOTH_AWARD_SEQUENCE_STATUS)) {
+            fieldValues.remove("awardSequenceStatus");
+            fieldValues.put("awardSequenceStatus", ACTIVE_OR_PENDING_AWARD_SEQUENCE_STATUS);
+        }
+
         List<Award> searchResults = (List<Award>)getVersionHistoryLookupDao().
                 getSequenceOwnerSearchResults(Award.class, fieldValues, usePrimaryKeys);
         List<String> activeAwards = new ArrayList<>();
         List<Long> awardIds = new ArrayList<>();
         for (Object object : searchResults) {
             Award awardSearchBo = (Award)object;
-            if(VersionStatus.ACTIVE.toString().equalsIgnoreCase(awardSearchBo.getAwardSequenceStatus())) {
-                activeAwards.add(awardSearchBo.getAwardNumber());
-                awardIds.add(awardSearchBo.getAwardId());
-            } else if(!activeAwards.contains(awardSearchBo.getAwardNumber()) && checkAwardHasActiveTnMDocument(awardSearchBo)) {
+            boolean addAwardToList = false;
+
+            if (fieldValues.containsKey("awardSequenceStatus")) {
+                if (fieldValues.get("awardSequenceStatus").toString().equalsIgnoreCase(PENDING_AWARD_SEQUENCE_STATUS)) {
+                    if (awardSearchBo.getVersionHistory().getStatusForOjb().equals(VersionStatus.PENDING.toString())) {
+                        addAwardToList = true;
+                    }
+                }
+                else if (fieldValues.get("awardSequenceStatus").toString().equalsIgnoreCase(ACTIVE_AWARD_SEQUENCE_STATUS)) {
+                    if (awardSearchBo.getAwardSequenceStatus() .equals(VersionStatus.ACTIVE.toString())) {
+                        addAwardToList = true;
+                    }
+                }
+                else if(fieldValues.get("awardSequenceStatus").toString().equalsIgnoreCase(ACTIVE_OR_PENDING_AWARD_SEQUENCE_STATUS)) {
+                    if ((awardSearchBo.getVersionHistory().getStatusForOjb().equals(VersionStatus.PENDING.toString()) &&
+                            isMostRecentVersion(awardSearchBo.getAwardNumber(), PENDING_AWARD_SEQUENCE_STATUS, "")) ||
+                            (awardSearchBo.getVersionHistory().getStatusForOjb().equals(VersionStatus.ACTIVE.toString()) &&
+                                    isMostRecentVersion(awardSearchBo.getAwardNumber(), "", ACTIVE_AWARD_SEQUENCE_STATUS)) ) {
+                        addAwardToList = true;
+                    }
+                }
+            }
+
+            else if(!activeAwards.contains(awardSearchBo.getAwardNumber()) && checkAwardHasActiveTnMDocument(awardSearchBo)){
+                addAwardToList = true;
+            }
+
+            if (addAwardToList) {
                 activeAwards.add(awardSearchBo.getAwardNumber());
                 awardIds.add(awardSearchBo.getAwardId());
             }
@@ -97,6 +143,53 @@ public class AwardLookupDaoOjb extends LookupDaoOjb  implements AwardLookupDao{
         }
         
         return false;
+    }
+
+    public boolean isMostRecentVersion(String awardNumber, String pendingStatus, String activeStatus) {
+        PersistenceBroker broker = null;
+        Connection conn = null;
+        ResultSet rs = null;
+        PreparedStatement stmt = null;
+        boolean isMostRecentVersion = false;
+
+        try {
+            broker = getPersistenceBroker(false);
+            conn = broker.serviceConnectionManager().getConnection();
+            String query = "select award_number from award b where award_sequence_status in (?, ?) and " +
+                    "award_number= ? and sequence_number=(select max(sequence_number) from award p where p.award_number=b.award_number)";
+            stmt = conn.prepareStatement(query);
+            stmt.setString(1, pendingStatus);
+            stmt.setString(2, activeStatus);
+            stmt.setString(3, awardNumber);
+            rs = stmt.executeQuery();
+
+            try {
+                if  (rs.next()) {
+                    isMostRecentVersion = true;
+                }
+            }
+            finally {
+                try { rs.close(); } catch (Exception ignore) { }
+            }
+        } catch (SQLException sqle) {
+            LOG.error("SQLException: " + sqle.getMessage(), sqle);
+            throw new WorkflowRuntimeException(sqle);
+        } catch (LookupException le) {
+            LOG.error("LookupException: " + le.getMessage(), le);
+            throw new WorkflowRuntimeException(le);
+        } finally {
+            try {
+                if(stmt != null) {
+                    stmt.close();
+                }
+                if (broker != null) {
+                    OjbFactoryUtils.releasePersistenceBroker(broker, this.getPersistenceBrokerTemplate().getPbKey());
+                }
+            } catch (Exception e) {
+                LOG.error("Failed closing connection: " + e.getMessage(), e);
+            }
+        }
+        return isMostRecentVersion;
     }
 
     public VersionHistoryLookupDao getVersionHistoryLookupDao() {

--- a/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
@@ -19,12 +19,16 @@
 package org.kuali.kra.award.home;
 
 import org.apache.commons.lang3.StringUtils;
-import org.kuali.coeus.award.finance.AwardAccount;
+import org.kuali.coeus.common.budget.framework.core.Budget;
+import org.kuali.coeus.common.budget.framework.core.BudgetParent;
+import org.kuali.coeus.common.budget.framework.core.BudgetParentDocument;
+import org.kuali.coeus.common.framework.auth.SystemAuthorizationService;
+import org.kuali.coeus.common.framework.auth.perm.Permissionable;
 import org.kuali.coeus.common.framework.keyword.KeywordsManager;
 import org.kuali.coeus.common.framework.keyword.ScienceKeyword;
 import org.kuali.coeus.common.framework.person.KcPerson;
 import org.kuali.coeus.common.framework.person.KcPersonService;
-import org.kuali.coeus.common.framework.version.sequence.owner.SequenceOwner;
+import org.kuali.coeus.common.framework.rolodex.PersonRolodex;
 import org.kuali.coeus.common.framework.sponsor.Sponsor;
 import org.kuali.coeus.common.framework.sponsor.Sponsorable;
 import org.kuali.coeus.common.framework.type.ActivityType;
@@ -34,9 +38,9 @@ import org.kuali.coeus.common.framework.unit.UnitService;
 import org.kuali.coeus.common.framework.unit.admin.UnitAdministrator;
 import org.kuali.coeus.common.framework.version.VersionStatus;
 import org.kuali.coeus.common.framework.version.history.VersionHistorySearchBo;
+import org.kuali.coeus.common.framework.version.sequence.owner.SequenceOwner;
 import org.kuali.coeus.common.permissions.impl.PermissionableKeys;
-import org.kuali.coeus.common.framework.auth.SystemAuthorizationService;
-import org.kuali.coeus.common.framework.auth.perm.Permissionable;
+import org.kuali.coeus.sys.api.model.ScaleTwoDecimal;
 import org.kuali.coeus.sys.framework.model.KcPersistableBusinessObjectBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.award.AwardAmountInfoService;
@@ -60,6 +64,7 @@ import org.kuali.kra.award.document.AwardDocument;
 import org.kuali.kra.award.home.approvedsubawards.AwardApprovedSubaward;
 import org.kuali.kra.award.home.fundingproposal.AwardFundingProposal;
 import org.kuali.kra.award.home.keywords.AwardScienceKeyword;
+import org.kuali.kra.award.lookup.AwardDocumentStatusConstants;
 import org.kuali.kra.award.notesandattachments.attachments.AwardAttachment;
 import org.kuali.kra.award.notesandattachments.notes.AwardNotepad;
 import org.kuali.kra.award.paymentreports.awardreports.AwardReportTerm;
@@ -69,11 +74,7 @@ import org.kuali.kra.award.paymentreports.specialapproval.approvedequipment.Awar
 import org.kuali.kra.award.paymentreports.specialapproval.foreigntravel.AwardApprovedForeignTravel;
 import org.kuali.kra.award.specialreview.AwardSpecialReview;
 import org.kuali.kra.award.timeandmoney.AwardDirectFandADistribution;
-import org.kuali.kra.bo.*;
-import org.kuali.coeus.common.budget.framework.core.Budget;
-import org.kuali.coeus.common.budget.framework.core.BudgetParent;
-import org.kuali.coeus.common.budget.framework.core.BudgetParentDocument;
-import org.kuali.coeus.common.framework.rolodex.PersonRolodex;
+import org.kuali.kra.bo.AccountType;
 import org.kuali.kra.coi.Disclosurable;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
@@ -88,13 +89,8 @@ import org.kuali.kra.timeandmoney.document.TimeAndMoneyDocument;
 import org.kuali.kra.timeandmoney.service.TimeAndMoneyHistoryService;
 import org.kuali.kra.timeandmoney.transactions.AwardTransactionType;
 import org.kuali.rice.core.api.CoreApiServiceLocator;
-import org.kuali.coeus.sys.api.model.ScaleTwoDecimal;
-import org.kuali.rice.core.api.criteria.CountFlag;
-import org.kuali.rice.core.api.criteria.QueryByCriteria;
-import org.kuali.rice.coreservice.framework.parameter.ParameterConstants;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kim.api.role.Role;
-import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.springframework.util.AutoPopulatingList;
 
@@ -198,6 +194,7 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
     private Date financialAccountCreationDate;
     private String financialChartOfAccountsCode;
     private String awardSequenceStatus;
+    private String awardSequenceStatusResult;
 
 
     private boolean newVersion;
@@ -336,6 +333,7 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
         setCurrentActionComments("");
         setNewVersion(false);
         awardSequenceStatus = VersionStatus.PENDING.name();
+        awardSequenceStatusResult = VersionStatus.PENDING.name();
     }
 
 
@@ -2530,6 +2528,20 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
 
     public void setAwardSequenceStatus(String awardSequenceStatus) {
         this.awardSequenceStatus = awardSequenceStatus;
+    }
+
+    public String getAwardSequenceStatusResult() {
+        awardSequenceStatusResult = AwardDocumentStatusConstants.Pending.description();
+        for (AwardDocumentStatusConstants status : AwardDocumentStatusConstants.values()) {
+            if (status.code().equals(getAwardSequenceStatus())) {
+                awardSequenceStatusResult = status.description();
+            }
+        }
+        return awardSequenceStatusResult;
+    }
+
+    public void setAwardSequenceStatusResult(String awardSequenceStatusResult) {
+        this.awardSequenceStatusResult = awardSequenceStatusResult;
     }
 
     @Override

--- a/coeus-impl/src/main/java/org/kuali/kra/award/lookup/AwardDocumentStatusConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/lookup/AwardDocumentStatusConstants.java
@@ -1,0 +1,24 @@
+package org.kuali.kra.award.lookup;
+
+public enum AwardDocumentStatusConstants {
+
+    Active ("ACTIVE", "Final"),
+    Pending("PENDING", "Saved"),
+    Both("BOTH", "Both");
+
+    private final String code;
+    private final String description;
+
+    AwardDocumentStatusConstants(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String description() {
+        return description;
+    }
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardDocumentStatusValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardDocumentStatusValuesFinder.java
@@ -1,0 +1,27 @@
+package org.kuali.kra.award.lookup.keyvalue;
+
+import org.kuali.kra.award.lookup.AwardDocumentStatusConstants;
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.krad.keyvalues.KeyValuesBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AwardDocumentStatusValuesFinder extends KeyValuesBase {
+
+    private static final long serialVersionUID = 319440830553541682L;
+
+    /**
+     * @see org.kuali.rice.krad.keyvalues.KeyValuesFinder#getKeyValues()
+     */
+    public List<KeyValue> getKeyValues() {
+        List<KeyValue> KeyValues = new ArrayList<KeyValue>();
+
+        for (AwardDocumentStatusConstants documentStatus : AwardDocumentStatusConstants.values()) {
+            KeyValues.add(new ConcreteKeyValue(documentStatus.code(), documentStatus.description()));
+        }
+        return KeyValues;
+    }
+
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationDaoOjb.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationDaoOjb.java
@@ -250,8 +250,18 @@ public class NegotiationDaoOjb extends LookupDaoOjb implements NegotiationDao {
         if (values == null) {
             return new ArrayList<Negotiation>();
         }
-        values.put("awardSequenceStatus", VersionStatus.ACTIVE.name());
         Criteria criteria = getCollectionCriteriaFromMap(new Award(), values);
+
+        Criteria activeAwardSubCriteria = new Criteria();
+        Collection<String> versionStatuses = new ArrayList();
+        versionStatuses.add("PENDING");
+        versionStatuses.add("ACTIVE");
+        activeAwardSubCriteria.addIn("awardSequenceStatus",versionStatuses);
+        ReportQueryByCriteria activeAwardIdsQuery = QueryFactory.newReportQuery(Award.class, activeAwardSubCriteria);
+        activeAwardIdsQuery.setAttributes(new String[]{"max(awardId)"});
+        activeAwardIdsQuery.addGroupBy("awardNumber");
+        criteria.addIn("awardId", activeAwardIdsQuery);
+
         Criteria negotiationCrit = new Criteria();
         ReportQueryByCriteria subQuery = QueryFactory.newReportQuery(Award.class, criteria);
         subQuery.setAttributes(new String[] {"awardNumber"});

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
@@ -108,6 +108,8 @@
                 <ref bean="Award-latestAwardAmountInfo.obligationExpirationDate"/>
                 <ref bean="Award-latestAwardAmountInfo.anticipatedTotalAmount"/>
                 <ref bean="Award-latestAwardAmountInfo.amountObligatedToDate"/>
+                <ref bean="Award-documentStatus" />
+                <ref bean="Award-documentStatusResult" />
             </list>
         </property>
       	<property name="relationships">
@@ -1425,6 +1427,42 @@
     <bean id="Award-latestAwardAmountInfo.anticipatedTotalAmount" parent="AwardAmountInfo-anticipatedTotalAmount"
           p:name="latestAwardAmountInfo.anticipatedTotalAmount"/>
 
+    <bean id="Award-documentStatus" parent="Award-documentStatus-parentBean" />
+    <bean id="Award-documentStatus-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="awardSequenceStatus" />
+        <property name="forceUppercase" value="false" />
+        <property name="label" value="Document Status" />
+        <property name="shortLabel" value="Document Status" />
+        <property name="maxLength" value="20" />
+        <property name="validationPattern" >
+            <bean parent="AlphaNumericValidationPattern"
+                  p:allowWhitespace="false" />
+        </property>
+        <property name="required" value="false" />
+        <property name="control">
+            <bean parent="RadioControlDefinition"
+                  p:valuesFinderClass="org.kuali.kra.award.lookup.keyvalue.AwardDocumentStatusValuesFinder"
+                  p:includeKeyInLabel="false" />
+        </property>
+        <property name="summary" value="Document Status" />
+        <property name="description" value="Document Status" />
+    </bean>
+
+    <bean id="Award-documentStatusResult" parent="Award-documentStatusResult-parentBean" />
+    <bean id="Award-documentStatusResult-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="awardSequenceStatusResult" />
+        <property name="forceUppercase" value="false" />
+        <property name="label" value="Document Status" />
+        <property name="shortLabel" value="Document Status" />
+        <property name="maxLength" value="20" />
+        <property name="required" value="false" />
+        <property name="control">
+            <bean parent="HiddenControlDefinition" />
+        </property>
+        <property name="summary" value="Document Status" />
+        <property name="description" value="Document Status" />
+    </bean>
+
 
     <!-- Business Object Inquiry Definition -->
     <bean id="Award-inquiryDefinition" parent="Award-inquiryDefinition-parentBean"/>
@@ -1516,6 +1554,7 @@
                 <bean p:attributeName="closeoutDate" parent="FieldDefinition"/>
                 <bean p:attributeName="projectPersons.awardContactId" parent="FieldDefinition" p:hidden="true"/>
                 <bean p:attributeName="subPlanFlag" parent="FieldDefinition" p:hidden="true"/>
+                <bean p:attributeName="awardSequenceStatus" parent="FieldDefinition" p:defaultValue="BOTH" />
             </list>
         </property>
         <property name="resultFields">
@@ -1535,6 +1574,7 @@
                 <bean p:attributeName="latestAwardAmountInfo.finalExpirationDate" parent="FieldDefinition"/>
                 <bean p:attributeName="archiveLocation" parent="FieldDefinition"/>
                 <bean p:attributeName="closeoutDate" parent="FieldDefinition"/>
+                <bean p:attributeName="awardSequenceStatusResult" parent="FieldDefinition" />
             </list>
         </property>
     </bean>
@@ -1560,6 +1600,7 @@
                 <bean p:propertyName="closeoutDate" parent="Uif-LookupCriteriaInputField"/>
                 <bean p:propertyName="projectPersons.awardContactId" parent="Uif-LookupCriteriaInputField"/>
                 <bean p:propertyName="subPlanFlag" parent="Uif-LookupCriteriaInputField"/>
+                <bean p:propertyName="awardSequenceStatus" parent="Uif-LookupCriteriaInputField" p:defaultValue="BOTH" />
             </list>
         </property>
         <property name="resultFields">
@@ -1579,6 +1620,7 @@
                 <bean p:propertyName="latestAwardAmountInfo.finalExpirationDate" parent="Uif-DataField"/>
                 <bean p:propertyName="archiveLocation" parent="Uif-DataField"/>
                 <bean p:propertyName="closeoutDate" parent="Uif-DataField"/>
+                <bean p:propertyName="awardSequenceStatusResult" parent="Uif-DataField" />
             </list>
         </property>
     </bean>


### PR DESCRIPTION
RESSUP-1385

This enhancement allows Awards to be looked up based on their VersionHistory status-- either "ACTIVE", "PENDING", or both. It also adds the display of this status to the Award lookup results, and also enables the Negotiation lookup to work properly with associated Awards in saved / PENDING version status.