### PR TITLE
RESSUP-1416 Add new system parameter for filtering the "Transaction Type" drop down on Awards

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/rice/bootstrap/V1602_001_RESSUP-1416.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/rice/bootstrap/V1602_001_RESSUP-1416.sql
@@ -1,0 +1,3 @@
+INSERT INTO krcr_parm_t (nmspc_cd, cmpnt_cd, parm_nm, obj_id, ver_nbr, parm_typ_cd, val, parm_desc_txt, eval_oprtr_cd, appl_id)
+ VALUES ('KC-AWARD', 'Document', 'AwardTransactionTypeAllowedValues', sys_guid(), 1, 'CONFG', '', 'Parameter defining allowed Award Transaction Types in Award drop down', 'A', 'KC');
+ 

--- a/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardTransactionTypeBusinessObjectFilteredValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardTransactionTypeBusinessObjectFilteredValuesFinder.java
@@ -2,7 +2,6 @@ package org.kuali.kra.award.lookup.keyvalue;
 
 import java.util.*;
 
-import jdk.internal.org.objectweb.asm.tree.analysis.Value;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kra.award.home.ValidRates;
 import org.kuali.kra.infrastructure.Constants;
@@ -77,17 +76,12 @@ public class AwardTransactionTypeBusinessObjectFilteredValuesFinder extends Pers
         KeyValue [] labelsArray = labels.toArray(new KeyValue[labels.size()]);
         Iterator iter = transactionValues.iterator();
 
-                //        ValidAwardBasisPayment vBasisPayment = (ValidAwardBasisPayment)businessObjectService.findByPrimaryKey(ValidAwardBasisPayment.class, Collections.singletonMap(VALIDAWARDBASISPAYMENT_ID, validAwardBasisPaymentId));
-
         while (iter.hasNext()) {
             String filteredTransactionType = (String) iter.next();
-            Map<String,Object> qMap = new HashMap<>();
-            qMap.put(TRANSACTION_TYPE_CODE, filteredTransactionType);
-            AwardTransactionType awardTransactionType = (AwardTransactionType)businessObjectService.findByPrimaryKey(AwardTransactionType.class,qMap );
             for (int i = 0; i < labelsArray.length; i++) {
 
-                if (!StringUtils.isBlank(labelsArray[i].getValue()) && !StringUtils.isBlank(filteredTransactionType)) {
-                    if (awardTransactionType.getDescription().equalsIgnoreCase(labelsArray[i].getValue())) {
+                if (!StringUtils.isBlank(labelsArray[i].getKey()) && !StringUtils.isBlank(filteredTransactionType)) {
+                    if (StringUtils.equals(filteredTransactionType,labelsArray[i].getKey())) {
 
                         // The same index (key) should be used for the filtered list.
                         // Otherwise the value of the transaction type cannot be displayed for

--- a/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardTransactionTypeBusinessObjectFilteredValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/lookup/keyvalue/AwardTransactionTypeBusinessObjectFilteredValuesFinder.java
@@ -1,0 +1,126 @@
+package org.kuali.kra.award.lookup.keyvalue;
+
+import java.util.*;
+
+import jdk.internal.org.objectweb.asm.tree.analysis.Value;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kra.award.home.ValidRates;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.coeus.sys.framework.keyvalue.PrefixValuesFinder;
+import org.kuali.kra.timeandmoney.transactions.AwardTransactionType;
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.coreservice.framework.CoreFrameworkServiceLocator;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.krad.keyvalues.PersistableBusinessObjectValuesFinder;
+import org.kuali.rice.krad.service.BusinessObjectService;
+
+public class AwardTransactionTypeBusinessObjectFilteredValuesFinder extends PersistableBusinessObjectValuesFinder {
+
+    private static final String SYSTEM_PARAMETER_NAME = "AwardTransactionTypeAllowedValues";
+    private static final String SYSTEM_PARAMETER_CMPNT_CODE = "Document";
+    public static final String TRANSACTION_TYPE_CODE = "awardTransactionTypeCode";
+    BusinessObjectService businessObjectService;
+
+    class PBOComparator implements Comparator
+    {
+        public int compare(Object kv1, Object kv2 )
+        {
+            try
+            {
+                String desc1 = ((KeyValue)kv1).getValue();
+                String desc2 = ((KeyValue)kv2).getValue();
+                if (desc1 == null)
+                {
+                    desc1 = "";
+                }
+                if (desc2 == null)
+                {
+                    desc2 = "";
+                }
+                return desc1.compareTo(desc2);
+            }
+            catch (Exception e)
+            {
+                return 0;
+            }
+        }
+
+    }
+    /**
+     * Build the list of KeyValues using the key (keyAttributeName) and
+     * label (labelAttributeName) of the list of all business objects found
+     * for the BO class specified along with a "select" entry.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public List<KeyValue> getKeyValues(){
+        List<KeyValue> labels;
+
+        labels = super.getKeyValues();
+        Collections.sort(labels, new PBOComparator());
+        labels.add(0, new ConcreteKeyValue(PrefixValuesFinder.getPrefixKey(), PrefixValuesFinder.getDefaultPrefixValue()));
+
+        ParameterService parameterService = CoreFrameworkServiceLocator.getParameterService();
+        // "AwardTransactionTypeAllowedValues" is the value of "parm_nm" column in table "krcr_parm_t"
+        Collection<String> transactionValues = parameterService.getParameterValuesAsString(Constants.MODULE_NAMESPACE_AWARD, SYSTEM_PARAMETER_CMPNT_CODE, SYSTEM_PARAMETER_NAME);
+
+        // In case the above system parameter is not defined under table "krcr_parm_t"
+        // Let's return the full list of Award Transaction Types
+        if (transactionValues == null || transactionValues.size() == 0) {
+            return labels;
+        }
+
+        // Otherwise - System parameter has been defined
+        List<KeyValue> filteredLabels = new ArrayList<KeyValue>();
+        KeyValue [] labelsArray = labels.toArray(new KeyValue[labels.size()]);
+        Iterator iter = transactionValues.iterator();
+
+                //        ValidAwardBasisPayment vBasisPayment = (ValidAwardBasisPayment)businessObjectService.findByPrimaryKey(ValidAwardBasisPayment.class, Collections.singletonMap(VALIDAWARDBASISPAYMENT_ID, validAwardBasisPaymentId));
+
+        while (iter.hasNext()) {
+            String filteredTransactionType = (String) iter.next();
+            Map<String,Object> qMap = new HashMap<>();
+            qMap.put(TRANSACTION_TYPE_CODE, filteredTransactionType);
+            AwardTransactionType awardTransactionType = (AwardTransactionType)businessObjectService.findByPrimaryKey(AwardTransactionType.class,qMap );
+            for (int i = 0; i < labelsArray.length; i++) {
+
+                if (!StringUtils.isBlank(labelsArray[i].getValue()) && !StringUtils.isBlank(filteredTransactionType)) {
+                    if (awardTransactionType.getDescription().equalsIgnoreCase(labelsArray[i].getValue())) {
+
+                        // The same index (key) should be used for the filtered list.
+                        // Otherwise the value of the transaction type cannot be displayed for
+                        // readOnlyAlternateDisplay mode when opening the award page
+                        filteredLabels.add(new ConcreteKeyValue(labelsArray[i].getKey(), labelsArray[i].getValue()));
+                    }
+                }
+                // If any transaction type defined in table "krcr_parm_t" is not in the original drop down list
+                // Then we won't add it into the filtered list.
+            }
+        }
+
+        Collections.sort(filteredLabels, new PBOComparator());
+        // We need "select" on the top of the drop down list as well
+        filteredLabels.add(0, new ConcreteKeyValue(PrefixValuesFinder.getPrefixKey(), PrefixValuesFinder.getDefaultPrefixValue()));
+
+        return filteredLabels;
+    }
+
+    /**
+     * Gets the businessObjectService attribute.
+     * @return Returns the businessObjectService.
+     */
+    protected BusinessObjectService getBusinessObjectService() {
+        return businessObjectService;
+    }
+
+
+    /**
+     * Sets the businessObjectService attribute value.
+     * @param businessObjectService The businessObjectService to set.
+     */
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+}

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/Award.xml
@@ -1170,7 +1170,7 @@
         <property name="control">
             <bean parent="SelectControlDefinition"
                   p:businessObjectClass="org.kuali.kra.timeandmoney.transactions.AwardTransactionType"
-                  p:valuesFinderClass="org.kuali.coeus.sys.framework.keyvalue.ExtendedPersistableBusinessObjectValuesFinder"
+                  p:valuesFinderClass="org.kuali.kra.award.lookup.keyvalue.AwardTransactionTypeBusinessObjectFilteredValuesFinder"
                   p:includeKeyInLabel="false" p:includeBlankRow="false" p:keyAttribute="awardTransactionTypeCode"
                   p:labelAttribute="description"/>
         </property>


### PR DESCRIPTION
Includes a new rice parameter, initially set to an empty string, but can accept a semicolon delimited set of Award Transaction Type Codes.

If parameter is empty, all transaction type codes will be shown. 