### PR TITLE
[#RESSUP-1387] Added 'Document Status' field to SubAward lookup and results

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationDaoOjb.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/negotiations/lookup/NegotiationDaoOjb.java
@@ -323,6 +323,17 @@ public class NegotiationDaoOjb extends LookupDaoOjb implements NegotiationDao {
             return new ArrayList<Negotiation>();
         }
         Criteria criteria = getCollectionCriteriaFromMap(new SubAward(), values);
+
+        Criteria activeSubAwardSubCriteria = new Criteria();
+        Collection<String> versionStatuses = new ArrayList();
+        versionStatuses.add("PENDING");
+        versionStatuses.add("ACTIVE");
+        activeSubAwardSubCriteria.addIn("subAwardSequenceStatus",versionStatuses);
+        ReportQueryByCriteria activeSubAwardIdsQuery = QueryFactory.newReportQuery(SubAward.class, activeSubAwardSubCriteria);
+        activeSubAwardIdsQuery.setAttributes(new String[]{"max(subAwardId)"});
+        activeSubAwardIdsQuery.addGroupBy("subAwardCode");
+        criteria.addIn("subAwardId",activeSubAwardIdsQuery);
+
         Criteria negotiationCrit = new Criteria();
         ReportQueryByCriteria subQuery = QueryFactory.newReportQuery(SubAward.class, criteria);
         subQuery.setAttributes(new String[] {"subAwardId"});
@@ -330,7 +341,7 @@ public class NegotiationDaoOjb extends LookupDaoOjb implements NegotiationDao {
         negotiationCrit.addEqualTo(NEGOTIATION_TYPE_ATTR, 
                 getNegotiationService().getNegotiationAssociationType(NegotiationAssociationType.SUB_AWARD_ASSOCIATION).getId());
         Collection<Negotiation> result = this.findCollectionBySearchHelper(Negotiation.class, negotiationValues, false, false, negotiationCrit);
-        
+
         return result;
     }  
     

--- a/coeus-impl/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
@@ -41,6 +41,7 @@ import org.kuali.kra.negotiations.bo.NegotiationPersonDTO;
 import org.kuali.kra.subaward.customdata.SubAwardCustomData;
 import org.kuali.kra.subaward.document.SubAwardDocument;
 import org.kuali.coeus.sys.api.model.ScaleTwoDecimal;
+import org.kuali.kra.subaward.lookup.SubAwardDocumentStatusConstants;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.springframework.util.AutoPopulatingList;
 
@@ -352,6 +353,15 @@ implements Permissionable, SequenceOwner<SubAward>, Negotiable {
 	public void setSubAwardSequenceStatus(String subAwardSequenceStatus) {
 		this.subAwardSequenceStatus = subAwardSequenceStatus;
 	}
+
+    public String getSubAwardSequenceStatusResult() {
+        if (SubAwardDocumentStatusConstants.Active.code().equals(getSubAwardSequenceStatus())) {
+            return SubAwardDocumentStatusConstants.Active.description();
+        }
+        else {
+            return SubAwardDocumentStatusConstants.Pending.description();
+        }
+    }
 
 	public String getRolodexFirstName() {
         if (getRolodex() == null) {

--- a/coeus-impl/src/main/java/org/kuali/kra/subaward/lookup/SubAwardDocumentStatusConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/subaward/lookup/SubAwardDocumentStatusConstants.java
@@ -1,0 +1,25 @@
+package org.kuali.kra.subaward.lookup;
+
+public enum SubAwardDocumentStatusConstants {
+
+    Active ("ACTIVE", "Final"),
+    Pending("PENDING", "Saved"),
+    Both("BOTH", "Both");
+
+    private final String code;
+    private final String description;
+
+    SubAwardDocumentStatusConstants(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String description() {
+        return description;
+    }
+
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/subaward/lookup/SubAwardDocumentStatusValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/subaward/lookup/SubAwardDocumentStatusValuesFinder.java
@@ -1,0 +1,26 @@
+package org.kuali.kra.subaward.lookup;
+
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.krad.keyvalues.KeyValuesBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SubAwardDocumentStatusValuesFinder extends KeyValuesBase {
+
+    private static final long serialVersionUID = -3074955977161691637L;
+
+    /**
+     * @see org.kuali.rice.krad.keyvalues.KeyValuesFinder#getKeyValues()
+     */
+    public List<KeyValue> getKeyValues() {
+        List<KeyValue> KeyValues = new ArrayList<KeyValue>();
+
+        for (SubAwardDocumentStatusConstants documentStatus : SubAwardDocumentStatusConstants.values()) {
+            KeyValues.add(new ConcreteKeyValue(documentStatus.code(), documentStatus.description()));
+        }
+        return KeyValues;
+    }
+
+}

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/SubAward.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/SubAward.xml
@@ -72,6 +72,8 @@
         <ref bean="SubAward-modificationId" /> 
         <ref bean="SubAward-performanceStartDate" /> 
         <ref bean="SubAward-performanceEnddate" />
+        <ref bean="SubAward-documentStatus" />
+        <ref bean="SubAward-documentStatusResult" />
       </list>
     </property>
   </bean>
@@ -886,6 +888,42 @@
     <property name="description" value="Period of Performance End Date" />    
   </bean>
 
+  <bean id="SubAward-documentStatus" parent="SubAward-documentStatus-parentBean" />
+  <bean id="SubAward-documentStatus-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="subAwardSequenceStatus" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Document Status" />
+    <property name="shortLabel" value="Document Status" />
+    <property name="maxLength" value="20" />
+    <property name="validationPattern" >
+      <bean parent="AlphaValidationPattern"
+            p:allowWhitespace="false" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control">
+      <bean parent="RadioControlDefinition"
+            p:valuesFinderClass="org.kuali.kra.subaward.lookup.SubAwardDocumentStatusValuesFinder"
+            p:includeKeyInLabel="false" />
+    </property>
+    <property name="summary" value="Document Status" />
+    <property name="description" value="Document Status" />
+  </bean>
+
+  <bean id="SubAward-documentStatusResult" parent="SubAward-documentStatusResult-parentBean" />
+  <bean id="SubAward-documentStatusResult-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="subAwardSequenceStatusResult" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Document Status" />
+    <property name="shortLabel" value="Document Status" />
+    <property name="maxLength" value="20" />
+    <property name="required" value="false" />
+    <property name="control">
+      <bean parent="HiddenControlDefinition" />
+    </property>
+    <property name="summary" value="Document Status" />
+    <property name="description" value="Document Status" />
+  </bean>
+
   <!-- Business Object Inquiry Definition -->
   <bean id="SubAward-inquiryDefinition" parent="SubAward-inquiryDefinition-parentBean" />
   <bean id="SubAward-InquiryView" parent="SubAward-InquiryView-parentBean"/>
@@ -950,6 +988,7 @@
         <bean p:attributeName="requisitionerUnit" parent="FieldDefinition" p:forceInquiry="true" />
         <bean p:attributeName="archiveLocation" parent="FieldDefinition" p:forceInquiry="true" />
         <bean p:attributeName="closeoutDate" parent="FieldDefinition" p:forceInquiry="true" />
+        <bean p:attributeName="subAwardSequenceStatus" parent="FieldDefinition" p:defaultValue="BOTH" />
       </list>
     </property>
     <property name="resultFields" >
@@ -969,6 +1008,7 @@
         <bean p:attributeName="unit.unitName" parent="FieldDefinition" p:forceInquiry="true" />
         <bean p:attributeName="archiveLocation" parent="FieldDefinition" p:forceInquiry="true" />
         <bean p:attributeName="closeoutDate" parent="FieldDefinition" p:forceInquiry="true" />
+        <bean p:attributeName="subAwardSequenceStatusResult" parent="FieldDefinition"/>
       </list>
     </property>
   </bean>
@@ -994,6 +1034,7 @@
         <bean p:propertyName="requisitionerUnit" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="archiveLocation" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="closeoutDate" parent="Uif-LookupCriteriaInputField"/>
+        <bean p:propertyName="subAwardSequenceStatus" parent="Uif-LookupCriteriaInputField" p:defaultValue="BOTH" />
       </list>
     </property>
     <property name="resultFields">
@@ -1013,6 +1054,7 @@
         <bean p:propertyName="unit.unitName" parent="Uif-DataField"/>
         <bean p:propertyName="archiveLocation" parent="Uif-DataField"/>
         <bean p:propertyName="closeoutDate" parent="Uif-DataField"/>
+        <bean p:propertyName="subAwardSequenceStatusResult" parent="Uif-DataField" />
       </list>
     </property>
   </bean>


### PR DESCRIPTION
RESSUP-1387

This PR is closely related to RESSUP-1385 and pull request #1597. It adds a lookup and result field based on the subaward's sequence status, and updates the Negotiation lookup to account for the new potential of pending subawards being returned.
