### PR TITLE
[RESSUP-1434] Prevent the AWARD.UPDATE_USER field from updating when versioned

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
@@ -303,6 +303,7 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
     private List<SubAward> subAwardList;
     
     private transient boolean allowUpdateTimestampToBeReset = true;
+    private transient boolean allowUpdateUserToBeReset = true;
     
     private VersionHistorySearchBo versionHistory;
     private transient KcPersonService kcPersonService;
@@ -2603,6 +2604,27 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
             super.setUpdateTimestamp(updateTimestamp);
         } else {
             setAllowUpdateTimestampToBeReset(true);
+        }
+    }
+
+    /**
+     *
+     * Setting this value to false will prevent the update user field from being update just once.  After that, the update user field will update as regular.
+     */
+    public boolean isAllowUpdateUserToBeReset() {
+        return allowUpdateUserToBeReset;
+    }
+
+    public void setAllowUpdateUserToBeReset(boolean allowUpdateUserToBeReset) {
+        this.allowUpdateUserToBeReset = allowUpdateUserToBeReset;
+    }
+
+    @Override
+    public void setUpdateUser(String updateUser) {
+        if (isAllowUpdateUserToBeReset()) {
+            super.setUpdateUser(updateUser);
+        } else {
+            setAllowUpdateUserToBeReset(true);
         }
     }
     

--- a/coeus-impl/src/main/java/org/kuali/kra/award/home/AwardServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/home/AwardServiceImpl.java
@@ -209,6 +209,7 @@ public class AwardServiceImpl implements AwardService {
         for (Award award : awards) {
             award.setAwardSequenceStatus(VersionStatus.ARCHIVED.name());
             award.setAllowUpdateTimestampToBeReset(false);
+            award.setAllowUpdateUserToBeReset(false);
             businessObjectService.save(award);
         }
     }


### PR DESCRIPTION
As seen on the Award History screen, when an award is versioned, the original version does not update the UPDATE_TIMESTAMP field, but does update the UPDATE_USER field. This pull request fixes that and makes it so neither the UPDATE_TIMESTAMP nor UPDATE_USER fields are updated on the old award version