### PR TITLE
[#RESSUP-1460] Populate SubAward funding sources based on Award Number without requiring a full lookup.

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/home/Award.java
@@ -459,6 +459,10 @@ public class Award extends KcPersistableBusinessObjectBase implements KeywordsMa
         return returnVal;
     }
 
+    public double getAmountObligatedToDate() {
+        return awardAmountInfos.get(0).getAmountObligatedToDate().doubleValue();
+    }
+
     /**
      * If the Award is copied then initially the AwardAmountInfos will
      * have two entries without AwardAmountInfoId's.  We need to recognize this

--- a/coeus-impl/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
@@ -20,10 +20,10 @@ package org.kuali.kra.subaward.bo;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.kuali.coeus.common.framework.version.VersionStatus;
+import org.kuali.coeus.sys.api.model.ScaleTwoDecimal;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.award.home.Award;
 import org.kuali.kra.award.home.AwardAmountInfo;
-import org.kuali.coeus.sys.api.model.ScaleTwoDecimal;
 import org.kuali.rice.krad.service.BusinessObjectService;
 
 import java.sql.Date;
@@ -155,10 +155,15 @@ public class SubAwardFundingSource extends SubAwardAssociate {
 		if (getAward() != null) {
 			Map<String,Object> criteria = new HashMap<>();
 			criteria.put(AWARD_NUMBER, award.getAwardNumber());
-			criteria.put(AWARD_SEQUENCE_STATUS, VersionStatus.ACTIVE.toString());
 			List<Award> awards = (List<Award>) getBusinessObjectService().findMatchingOrderBy(Award.class, criteria, SEQUENCE_NUMBER, false);
 			if (CollectionUtils.isNotEmpty(awards)) {
 				activeAward = awards.get(0);
+			}
+			for (Award award : awards) {
+				if (VersionStatus.ACTIVE.toString().equals(award.getAwardSequenceStatus())) {
+					activeAward = award;
+					break;
+				}
 			}
 		}
 		return activeAward;

--- a/coeus-webapp/src/main/webapp/WEB-INF/dwr-kra.xml
+++ b/coeus-webapp/src/main/webapp/WEB-INF/dwr-kra.xml
@@ -57,6 +57,18 @@
         <convert converter="bean" match="org.kuali.rice.location.framework.state.StateEbo">
             <param name="include" value="code,name,countryCode" />
         </convert>
+		<convert converter="bean" match="org.kuali.kra.award.home.Award">
+			<param name="include" value="accountNumber,statusCode,sponsorCode,amountObligatedToDate,obligationExpirationDate, sponsorName,statusDescription,awardId,awardNumber,awardDocument" />
+		</convert>
+		<convert converter="bean" match="org.kuali.kra.award.home.AwardStatus">
+			<param name="include" value="statusCode,description" />
+		</convert>
+		<convert converter="bean" match="org.kuali.kra.award.home.AwardAmountInfo">
+			<param name="include" value="amountObligatedToDate,obligationExpirationDate" />
+		</convert>
+		<convert converter="bean" match="org.kuali.kra.award.document.AwardDocument">
+			<param name="include" value="documentNumber" />
+		</convert>
 
         <create creator="spring" javascript="SponsorService">
             <param name="beanName" value="sponsorService" />
@@ -127,6 +139,23 @@
 			<param name="beanName" value="awardPaymentAndInvoicesService" />			
 			<include method="getEncodedValidAwardBasisPaymentsByAwardTypeCode" />
 			<include method="getEncodedValidBasisMethodPaymentsByBasisCode" />
+		</create>
+		<create creator="spring" javascript="AwardService">
+			<param name="beanName" value="awardService" />
+			<include method="getActiveOrNewestAward" />
+			<include method="getAwardStatus" />
+			<include method="getAccountNumber" />
+			<include method="getStatusCode" />
+			<include method="getStatusDescription" />
+			<include method="getDescription" />
+			<include method="getSponsorCode" />
+			<include method="getSponsorName" />
+			<include method="getAwardId" />
+			<include method="getAmountObligatedToDate" />
+			<include method="getObligationExpirationDate" />
+			<include method="getAwardNumber" />
+			<include method="getAwardDocument" />
+			<include method="getDocumentNumber" />
 		</create>
 		<create creator="spring" javascript="ProtocolActionAjaxService">
 		    <param name="beanName" value="protocolActionAjaxService" />

--- a/coeus-webapp/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
+++ b/coeus-webapp/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
@@ -18,6 +18,8 @@
 --%>
 <%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
 
+<script type='text/javascript' src='dwr/interface/AwardService.js'></script>
+
 <c:set var="subAwardFundingSourceAttributes" value="${DataDictionary.SubAwardFundingSource.attributes}" />
 <c:set var="action" value="subAward" />
 <c:set var="subAwardFundingSource" value="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}"/>
@@ -46,20 +48,64 @@
                <th class="infoline" >
 						Add:
 				</th>
-     			 <td align="center"  colspan=3><kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardNumber" attributeEntry="${subAwardFundingSourceAttributes.awardId}" />
-     			 <c:if test="${readOnly!='true'}">
-                 <kul:lookup boClassName="org.kuali.kra.award.home.Award" fieldConversions="awardNumber:newSubAwardFundingSource.award.awardNumber,awardDocument.documentNumber:newSubAwardFundingSource.award.awardDocument.documentNumber,awardId:newSubAwardFundingSource.awardId,accountNumber:newSubAwardFundingSource.award.accountNumber,statusCode:newSubAwardFundingSource.award.statusCode,sponsorCode:newSubAwardFundingSource.award.sponsorCode,sponsorName:newSubAwardFundingSource.award.sponsorName,latestAwardAmountInfo.amountObligatedToDate:newSubAwardFundingSource.award.latestAwardAmountInfo.amountObligatedToDate,latestAwardAmountInfo.obligationExpirationDate:newSubAwardFundingSource.award.latestAwardAmountInfo.obligationExpirationDate,awardStatus.description:newSubAwardFundingSource.award.awardStatus.description" anchor="${tabKey}" />
-                 </c:if>
+     			 <td align="center"  colspan=3>
+					 <kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardNumber"
+											   attributeEntry="${subAwardFundingSourceAttributes.awardId}"
+											   onblur="loadFundingSourceAwardNumber('newSubAwardFundingSource.award.awardNumber',
+                								'key.accountNumber',
+                								'key.accountNumberHidden',
+                								'key.awardStatus',
+                								'key.awardStatusHidden',
+    							  				'key.amount',
+    							  				'key.amountHidden',
+    							  				'key.obligationExpirationDate',
+    							  				'key.obligationExpirationDateHidden',
+    							  				'key.sponsor',
+    							  				'key.sponsorCode',
+    							  				'key.sponsorName',
+    							  				'key.awardDocumentNumber',
+    							  				'key.awardId');" />
+
+     			 	<c:if test="${readOnly!='true'}">
+                 		<kul:lookup boClassName="org.kuali.kra.award.home.Award" fieldConversions="awardNumber:newSubAwardFundingSource.award.awardNumber,awardDocument.documentNumber:newSubAwardFundingSource.award.awardDocument.documentNumber,awardId:newSubAwardFundingSource.awardId,accountNumber:newSubAwardFundingSource.award.accountNumber,statusCode:newSubAwardFundingSource.award.statusCode,sponsorCode:newSubAwardFundingSource.award.sponsorCode,sponsorName:newSubAwardFundingSource.award.sponsorName,latestAwardAmountInfo.amountObligatedToDate:newSubAwardFundingSource.award.latestAwardAmountInfo.amountObligatedToDate,latestAwardAmountInfo.obligationExpirationDate:newSubAwardFundingSource.award.latestAwardAmountInfo.obligationExpirationDate,awardStatus.description:newSubAwardFundingSource.award.awardStatus.description" anchor="${tabKey}" />
+                 	</c:if>
+
+					 <html:hidden styleId ="key.awardId" property="newSubAwardFundingSource.awardId" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.awardId")}
+
+					 <html:hidden styleId ="key.awardNumber" property="newSubAwardFundingSource.award.awardNumber" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.awardNumber")}
+
+					 <html:hidden styleId ="key.awardDocumentNumber" property="newSubAwardFundingSource.award.awardDocument.documentNumber" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.awardDocument.documentNumber")}
+
+					 <html:hidden styleId ="key.accountNumberHidden" property="newSubAwardFundingSource.award.accountNumber" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.accountNumber")}
+
+					 <html:hidden styleId ="key.sponsorCode" property="newSubAwardFundingSource.award.sponsorCode" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.sponsorCode")}
+
+					 <html:hidden styleId ="key.sponsorName" property="newSubAwardFundingSource.award.sponsorName" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.sponsorName")}
+
+					 <html:hidden styleId ="key.awardStatusHidden" property="newSubAwardFundingSource.award.awardStatus.description" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.awardStatus.description")}
+
+					 <html:hidden styleId ="key.amountHidden" property="newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate")}
+
+					 <html:hidden styleId ="key.obligationExpirationDateHidden" property="newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate" />
+						 ${kfunc:registerEditableProperty(KualiForm, "newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate")}
                	</td>
-   				<td><div align="center">
+   				<td><div id="key.accountNumber" align="center">
      					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}" datePicker="false" />           
    					</div> 
    				</td>
-   				<td><div align="center">
+   				<td><div id="key.awardStatus" align="center">
      					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardStatus.description" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.statusCode}" datePicker="false" />         
    					</div> 
    				</td>
-					<td><div align="center">
+					<td><div id="key.sponsor" align="center">
 							<kul:htmlControlAttribute
 									property="newSubAwardFundingSource.award.sponsorCode" readOnly="true"
 									attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"
@@ -71,11 +117,11 @@
 									datePicker="false" />
 							</c:if> 
 						</div></td>
-					<td><div align="center">
+					<td><div id="key.amount" align="center">
      					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.latestAwardAmountInfo.amountObligatedToDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}" datePicker="false" />
    					</div> 
    				</td>	
-   				<td><div align="center">
+   				<td><div id="key.obligationExpirationDate" align="center">
      					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.latestAwardAmountInfo.obligationExpirationDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" datePicker="false" />
    					</div> 
    				</td>		

--- a/coeus-webapp/src/main/webapp/scripts/kuali_application.js
+++ b/coeus-webapp/src/main/webapp/scripts/kuali_application.js
@@ -920,6 +920,115 @@ function loadContactPersonName(usernameFieldName, fullnameElementId,
 	}
 }
 
+	function loadFundingSourceAwardNumber(awardNumberFieldName, accountNumberElementId, accountNumberHiddenElementId,
+										  awardStatusElementId, awardStatusHiddenElementId, amountElementId, amountHiddenElementId,
+										  obligationExpirationDateElementId, obligationExpirationDateHiddenElementId, sponsorElementId,
+										  sponsorCodeElementId, sponsorNameElementId, awardDocumentNumberElementId, awardIdElementId) {
+
+		if (dwr.util.getValue( awardNumberFieldName ) != null) {
+			var awardNumber = dwr.util.getValue( awardNumberFieldName );
+			var accountNumberElement = document.getElementById(accountNumberElementId);
+			var accountNumberHiddenElement = document.getElementById(accountNumberHiddenElementId);
+
+			var awardStatusElement= document.getElementById(awardStatusElementId);
+			var awardStatusHiddenElement = document.getElementById(awardStatusHiddenElementId);
+			var sponsorElement = document.getElementById(sponsorElementId);
+			var sponsorCodeElement = document.getElementById(sponsorCodeElementId);
+			var sponsorNameElement = document.getElementById(sponsorNameElementId);
+
+			var amountElement = document.getElementById(amountElementId);
+			var amountHiddenElement = document.getElementById(amountHiddenElementId);
+			var obligationExpirationDateElement = document.getElementById(obligationExpirationDateElementId);
+			var obligationExpirationDateHiddenElement = document.getElementById(obligationExpirationDateHiddenElementId);
+
+			var awardIdElement = document.getElementById(awardIdElementId);
+			var awardDocumentNumberElement = document.getElementById(awardDocumentNumberElementId);
+			var sponsorConcatString = " : ";
+
+			var dwrReply = {
+				callback:function(data) {
+					if ( data != null ) {
+						if (accountNumberElement != null) accountNumberElement.innerHTML = data.accountNumber;
+						if (accountNumberHiddenElement != null) accountNumberHiddenElement.value = data.accountNumber;
+
+						if (awardStatusElement != null) {
+							if (data.statusCode == "1") {
+								awardStatusElement.innerHTML = "Active";
+							}
+							else if (data.statusCode == "3") {
+								awardStatusElement.innerHTML = "Saved";
+							}
+						}
+						if (awardStatusHiddenElement != null) {
+							if (data.statusCode == "1") {
+								awardStatusHiddenElement.value = "Active";
+							}
+							else if (data.statusCode == "3") {
+								awardStatusHiddenElement.value = "Saved";
+							}
+						}
+						if (amountElement != null) {
+							amountElement.innerHTML = data.amountObligatedToDate;
+							amountElement.value = data.amountObligatedToDate;
+						}
+
+						if (amountHiddenElement != null) {
+							amountHiddenElement.innerHTML = data.amountObligatedToDate;
+							amountHiddenElement.value = data.amountObligatedToDate;
+						}
+
+						if (obligationExpirationDateElement != null) obligationExpirationDateElement.innerHTML = formattedDate(data.obligationExpirationDate);
+						if (awardIdElement != null) awardIdElement.value = data.awardId;
+						if (sponsorElement != null) sponsorElement.innerHTML = (data.sponsorCode.concat(sponsorConcatString)).concat(data.sponsorName);
+						if (sponsorCodeElement != null) { sponsorCodeElement.value = data.sponsorCode; sponsorCodeElement.innerHTML = data.sponsorCode; }
+						if (sponsorNameElement != null) { sponsorNameElement.value = data.sponsorName; sponsorNameElement.innerHTML = data.sponsorName; }
+
+						if (obligationExpirationDateHiddenElement != null) {
+							obligationExpirationDateHiddenElement.value = formattedDate(data.obligationExpirationDate);
+							obligationExpirationDateHiddenElement.innerHTML = formattedDate(data.obligationExpirationDate);
+						}
+						if (awardDocumentNumberElement != null) {
+							awardDocumentNumberElement.value = data.awardDocument['documentNumber'];
+							awardDocumentNumberElement.innerHTML = data.awardDocument['documentNumber'];
+						}
+					}
+					else {
+						if (accountNumberElement != null) accountNumberElement.innerHTML = wrapError( "not found" );
+						if (awardStatusElement != null) awardStatusElement.innerHTML = wrapError( "not found" );
+						if (sponsorElement != null) sponsorElement.innerHTML = wrapError( "not found" );
+						if (amountElement != null) amountElement.innerHTML.innerHTML = wrapError( "not found" );
+						if (obligationExpirationDateElement != null) obligationExpirationDateElement.innerHTML = wrapError( "not found" );
+						if (awardDocumentNumberElement != null) awardDocumentNumberElement.value = "";
+						if (awardIdElement != null) awardIdElement.value = "";
+					}
+				},
+				errorHandler:function( errorMessage ) {
+					window.status = errorMessage;
+					if (accountNumberElement != null) accountNumberElement.innerHTML = wrapError( "not found" );
+					if (awardStatusElement != null) awardStatusElement.innerHTML = wrapError( "not found" );
+					if (sponsorElement != null) sponsorElement.innerHTML = wrapError( "not found" );
+					if (amountElement != null) amountElement.innerHTML.innerHTML = wrapError( "not found" );
+					if (obligationExpirationDateElement != null) obligationExpirationDateElement.innerHTML = wrapError( "not found" );
+					if (awardDocumentNumberElement != null) awardDocumentNumberElement.value = "";
+					if (awardIdElement != null) awardIdElement.value = null;
+				}
+			};
+			AwardService.getActiveOrNewestAward(awardNumber, dwrReply);
+		}
+	}
+
+	function formattedDate(date) {
+		var dateValue = new Date(date || Date.now()),
+			month = '' + (dateValue.getMonth() + 1),
+			day   = '' + dateValue.getDate(),
+			year  = dateValue.getFullYear();
+
+		if (month.length < 2) month = '0' + month;
+		if (day.length < 2)   day   = '0' + day;
+
+		return [month, day, year].join('/');
+	}
+
 	/*
 	 * Load the phone number and email address from rolodex info from rolodex id.
 	 */


### PR DESCRIPTION
RESSUP-1460

This pull request adds functionality to populate the funding sources panel in SubAwards via a DWR call instead of having to return an Award from the lookup. It also adds support for showing the latest Award version in the funding sources panel (instead of the ACTIVE) version, to support other statuses such as Canceled and Pending (see https://github.com/kuali/kc/pull/1597 for more info on returning Pending sequence status Awards from the Award lookup).