### PR TITLE
[RESSUP-1493] Making protocol numbers availble for IP and Award notifications

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/notification/impl/SpecialReviewNotificationRenderer.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/notification/impl/SpecialReviewNotificationRenderer.java
@@ -1,0 +1,31 @@
+package org.kuali.coeus.common.notification.impl;
+
+import java.util.Map;
+
+import org.kuali.coeus.common.framework.compliance.core.SpecialReview;
+
+
+public class SpecialReviewNotificationRenderer extends NotificationRendererBase {
+
+    private static final long serialVersionUID = 1946945581636879395L;
+
+    public static final String SPECIAL_REVIEW_PROTOCOL_NUMBER_PARAM = "{PROTOCOL_NUMBER}";
+
+    private NotificationRenderer internalRenderer;
+    private SpecialReview<?> specialReview;
+
+    public SpecialReviewNotificationRenderer(NotificationRenderer internalRenderer, SpecialReview<?> specialReview) {
+        this.internalRenderer = internalRenderer;
+        this.specialReview = specialReview;
+    }
+
+    @Override
+    public Map<String, String> getDefaultReplacementParameters() {
+        Map<String, String> parameters = internalRenderer.getDefaultReplacementParameters();
+        parameters.put(SPECIAL_REVIEW_PROTOCOL_NUMBER_PARAM, this.specialReview.getProtocolNumber());
+        return parameters;
+    }
+
+
+
+}

--- a/coeus-impl/src/main/java/org/kuali/kra/award/web/struts/action/AwardSpecialReviewAction.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/web/struts/action/AwardSpecialReviewAction.java
@@ -27,11 +27,14 @@ import org.kuali.coeus.common.framework.compliance.core.AddSpecialReviewEvent;
 import org.kuali.coeus.common.framework.compliance.core.SaveSpecialReviewEvent;
 import org.kuali.coeus.common.framework.compliance.core.SaveSpecialReviewLinkEvent;
 import org.kuali.coeus.common.framework.compliance.core.SpecialReviewService;
+import org.kuali.coeus.common.notification.impl.SpecialReviewNotificationRenderer;
+import org.kuali.coeus.common.notification.impl.NotificationRenderer;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.award.AwardForm;
 import org.kuali.kra.award.document.AwardDocument;
 import org.kuali.kra.award.home.Award;
 import org.kuali.kra.award.notification.AwardNotificationContext;
+import org.kuali.kra.award.notification.AwardNotificationRenderer;
 import org.kuali.kra.award.specialreview.AwardSpecialReview;
 import org.kuali.coeus.common.framework.compliance.core.SpecialReviewType;
 import org.kuali.kra.infrastructure.Constants;
@@ -122,13 +125,14 @@ public class AwardSpecialReviewAction extends AwardAction {
             if (specialReview.getSpecialReviewType() == null) {
                 specialReview.refreshReferenceObject("specialReviewType");
             }
-            AwardNotificationContext context = null; 
+            AwardNotificationContext context = null;
+            NotificationRenderer renderer = new SpecialReviewNotificationRenderer(new AwardNotificationRenderer(document.getAward()), specialReview);
             if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.HUMAN_SUBJECTS)) {
-                context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IRB_SPECIAL_REVIEW_LINK_ADDED, "Special Review Inserted", 
-                                                       Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
+                context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IRB_SPECIAL_REVIEW_LINK_ADDED, "Special Review Inserted",
+                        renderer, Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
             } else if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.ANIMAL_USAGE)) {
-                context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IACUC_SPECIAL_REVIEW_LINK_ADDED, "Special Review Inserted", 
-                        Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
+                context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IACUC_SPECIAL_REVIEW_LINK_ADDED, "Special Review Inserted",
+                        renderer, Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
             }
             if (context != null) {
                 if (awardForm.getNotificationHelper().getPromptUserForNotificationEditor(context)) {
@@ -184,13 +188,14 @@ public class AwardSpecialReviewAction extends AwardAction {
             if (specialReview.getSpecialReviewType() == null) {
                 specialReview.refreshReferenceObject("specialReviewType");
             }
-            AwardNotificationContext context = null; 
+            AwardNotificationContext context = null;
+            NotificationRenderer renderer = new SpecialReviewNotificationRenderer(new AwardNotificationRenderer(document.getAward()), specialReview);
             if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.HUMAN_SUBJECTS)) {
-                    context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IRB_SPECIAL_REVIEW_LINK_DELETED, "Special Review Deleted", 
-                                                           Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
+                    context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IRB_SPECIAL_REVIEW_LINK_DELETED, "Special Review Deleted",
+                            renderer, Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
             } else if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.ANIMAL_USAGE)) {
-                    context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IACUC_SPECIAL_REVIEW_LINK_DELETED, "Special Review Deleted", 
-                                                           Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
+                    context = new AwardNotificationContext(document.getAward(), Award.NOTIFICATION_IACUC_SPECIAL_REVIEW_LINK_DELETED, "Special Review Deleted",
+                            renderer,  Constants.MAPPING_AWARD_SPECIAL_REVIEW_PAGE);
             }
             if (context != null) {
                 if (awardForm.getNotificationHelper().getPromptUserForNotificationEditor(context)) {

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/web/struts/action/InstitutionalProposalSpecialReviewAction.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/web/struts/action/InstitutionalProposalSpecialReviewAction.java
@@ -27,15 +27,18 @@ import org.kuali.coeus.common.framework.compliance.core.AddSpecialReviewEvent;
 import org.kuali.coeus.common.framework.compliance.core.SaveSpecialReviewEvent;
 import org.kuali.coeus.common.framework.compliance.core.SaveSpecialReviewLinkEvent;
 import org.kuali.coeus.common.framework.compliance.core.SpecialReviewService;
+import org.kuali.coeus.common.notification.impl.NotificationRenderer;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.coeus.common.framework.compliance.core.SpecialReviewType;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.kra.institutionalproposal.document.InstitutionalProposalDocument;
 import org.kuali.kra.institutionalproposal.notification.InstitutionalProposalNotificationContext;
+import org.kuali.kra.institutionalproposal.notification.InstitutionalProposalNotificationRenderer;
 import org.kuali.kra.institutionalproposal.specialreview.InstitutionalProposalSpecialReview;
 import org.kuali.kra.institutionalproposal.web.struts.form.InstitutionalProposalForm;
 import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.coeus.common.notification.impl.SpecialReviewNotificationRenderer;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -122,8 +125,9 @@ public class InstitutionalProposalSpecialReviewAction extends InstitutionalPropo
                 specialReview.refreshReferenceObject("specialReviewType");
             }
             if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.HUMAN_SUBJECTS)) {
-                InstitutionalProposalNotificationContext context = 
-                    new InstitutionalProposalNotificationContext(document.getInstitutionalProposal(), "552", "Special Review Inserted", Constants.MAPPING_INSTITUTIONAL_PROPOSAL_SPECIAL_REVIEW_PAGE);
+                NotificationRenderer renderer = new SpecialReviewNotificationRenderer(new InstitutionalProposalNotificationRenderer(document.getInstitutionalProposal()), specialReview);
+                InstitutionalProposalNotificationContext context =
+                        new InstitutionalProposalNotificationContext(document.getInstitutionalProposal(), "552", "Special Review Inserted", renderer, Constants.MAPPING_INSTITUTIONAL_PROPOSAL_SPECIAL_REVIEW_PAGE);
                 if (institutionalProposalForm.getNotificationHelper().getPromptUserForNotificationEditor(context)) {
                     institutionalProposalForm.getNotificationHelper().initializeDefaultValues(context);
                     forward = mapping.findForward("notificationEditor");
@@ -175,8 +179,9 @@ public class InstitutionalProposalSpecialReviewAction extends InstitutionalPropo
             InstitutionalProposalSpecialReview specialReview = document.getInstitutionalProposal().getSpecialReviews().get(getLineToDelete(request));
             document.getInstitutionalProposal().getSpecialReviews().remove(specialReview);
             if (StringUtils.equals(specialReview.getSpecialReviewType().getSpecialReviewTypeCode(), SpecialReviewType.HUMAN_SUBJECTS)) {
-                InstitutionalProposalNotificationContext context = 
-                    new InstitutionalProposalNotificationContext(document.getInstitutionalProposal(), "553", "Special Review Deleted", Constants.MAPPING_INSTITUTIONAL_PROPOSAL_SPECIAL_REVIEW_PAGE);
+                NotificationRenderer renderer = new SpecialReviewNotificationRenderer(new InstitutionalProposalNotificationRenderer(document.getInstitutionalProposal()), specialReview);
+                InstitutionalProposalNotificationContext context =
+                        new InstitutionalProposalNotificationContext(document.getInstitutionalProposal(), "553", "Special Review Deleted", renderer, Constants.MAPPING_INSTITUTIONAL_PROPOSAL_SPECIAL_REVIEW_PAGE);
                 if (institutionalProposalForm.getNotificationHelper().getPromptUserForNotificationEditor(context)) {
                     institutionalProposalForm.getNotificationHelper().initializeDefaultValues(context);
                     forward = mapping.findForward("notificationEditor");


### PR DESCRIPTION
RESSUP-1493

Makes a new replacement parameter {PROTOCOL_NUMBER} available in the subject and message text of Award and IP special review notifications.
