### PR TITLE
[#RESSUP-1593] Created KC Fiscal Officer Derived Role to grant KFS...

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/rice/bootstrap/V1604_001__RESSUP-1593.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/oracle/rice/bootstrap/V1604_001__RESSUP-1593.sql
@@ -1,0 +1,4 @@
+INSERT INTO KRIM_TYP_T (KIM_TYP_ID, OBJ_ID, VER_NBR, NM, SRVC_NM, ACTV_IND, NMSPC_CD)
+VALUES( KRIM_TYP_ID_S.NEXTVAL, SYS_GUID(), 1, 'Derived Role: Fiscal Officer', '{http://kc.kuali.org/core/v5_0}fiscalOfficerDerivedRoleTypeService', 'Y', 'KC-AWARD');
+INSERT INTO KRIM_ROLE_T (ROLE_ID, OBJ_ID, VER_NBR, ROLE_NM, NMSPC_CD, DESC_TXT, KIM_TYP_ID, ACTV_IND, LAST_UPDT_DT)
+VALUES (KRIM_ROLE_PERM_ID_S.NEXTVAL, SYS_GUID(), 1, 'KC Fiscal Officer', 'KC-AWARD', 'Role for granting Fiscal Officers KC permissions', (SELECT KIM_TYP_ID FROM KRIM_TYP_T WHERE NM = 'Derived Role: Fiscal Officer'), 'Y', SYSDATE);

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/notification/impl/lookup/keyvalue/NotificationModuleRoleQualifierValuesFinder.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/notification/impl/lookup/keyvalue/NotificationModuleRoleQualifierValuesFinder.java
@@ -45,6 +45,7 @@ public class NotificationModuleRoleQualifierValuesFinder extends UifKeyValuesFin
         documentList.add(new ConcreteKeyValue("negotiation", "Negotiation Id"));
         documentList.add(new ConcreteKeyValue("coiDisclosureId", "Disclosure Id"));
         documentList.add(new ConcreteKeyValue(KcKimAttributes.PROPOSAL, "Proposal"));
+        documentList.add(new ConcreteKeyValue(KcKimAttributes.AWARD, "Award"));
         documentList.add(new ConcreteKeyValue(KimConstants.AttributeConstants.DOCUMENT_NUMBER, "Document Number"));
         
         return documentList;

--- a/coeus-impl/src/main/java/org/kuali/kra/kfs/coa/identity/FiscalOfficerDerivedRoleTypeServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/kfs/coa/identity/FiscalOfficerDerivedRoleTypeServiceImpl.java
@@ -1,0 +1,117 @@
+package org.kuali.kra.kfs.coa.identity;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.award.home.AwardService;
+import org.kuali.kra.kim.bo.KcKimAttributes;
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.role.RoleMembership;
+import org.kuali.rice.kim.api.role.RoleService;
+import org.kuali.rice.kns.kim.role.DerivedRoleTypeServiceBase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FiscalOfficerDerivedRoleTypeServiceImpl  extends DerivedRoleTypeServiceBase {
+
+    protected static final String FISCAL_OFFICER_ROLE_NAMESPACE = "KFS-SYS";
+    protected static final String FISCAL_OFFICER_ROLE_NAME = "Fiscal Officer";
+
+    protected static final String ACCOUNT_NUMBER_QUALIFIER = "accountNumber";
+    protected static final String FIN_COA_CODE_QUALIFIER = "chartOfAccountsCode";
+
+    protected RoleService roleService;
+    protected AwardService awardService;
+
+    protected List<String> requiredAttributes = new ArrayList<String>();
+    {
+        requiredAttributes.add(KcKimAttributes.AWARD);
+    }
+
+    @Override
+    public boolean hasDerivedRole(String principalId, List<String> groupIds, String namespaceCode,
+                                  String roleName, Map<String,String> qualification) {
+        Map<String, String> kfsQualification = translateAwardToAccountQualification(qualification);
+        List<String> fiscalOfficerRoleId = getFiscalOfficerRoleIdAsList();
+
+        if (!fiscalOfficerRoleId.isEmpty()) {
+            return roleService.principalHasRole(principalId, fiscalOfficerRoleId, kfsQualification);
+        }
+
+        return false;
+    }
+
+    public List<RoleMembership> getRoleMembersFromDerivedRole(String namespaceCode, String roleName, Map<String,String> qualification) {
+        validateRequiredAttributesAgainstReceived(qualification);
+        Map<String, String> kfsQualification = translateAwardToAccountQualification(qualification);
+        List<String> fiscalOfficerRoleId = getFiscalOfficerRoleIdAsList();
+
+        if (!fiscalOfficerRoleId.isEmpty()) {
+            return roleService.getRoleMembers(fiscalOfficerRoleId, kfsQualification);
+        }
+
+        return new ArrayList<RoleMembership>();
+    }
+
+    protected Map<String, String> translateAwardToAccountQualification(Map<String,String> qualification) {
+        if (qualification == null) {
+            return new HashMap<String, String>();
+        }
+        Map<String, String> translatedQualifications = new HashMap<String, String>(qualification);
+        Award award = null;
+        String awardIdStr = translatedQualifications.get(KcKimAttributes.AWARD);
+        if (StringUtils.isNotBlank(awardIdStr) && awardIdStr.matches("\\d+")) {
+            Long awardId = Long.valueOf(awardIdStr);
+            award = getAwardService().getAward(awardId);
+        }
+        if (award != null && StringUtils.isNotBlank(award.getAccountNumber()) && StringUtils.isNotBlank(award.getFinancialChartOfAccountsCode())) {
+            translatedQualifications.remove(KcKimAttributes.AWARD);
+            translatedQualifications.put(ACCOUNT_NUMBER_QUALIFIER, award.getAccountNumber());
+            translatedQualifications.put(FIN_COA_CODE_QUALIFIER, award.getFinancialChartOfAccountsCode());
+        }
+        return translatedQualifications;
+    }
+
+    protected String getFiscalOfficerRoleId() {
+        Role fiscalOfficerRole = getRoleService().getRoleByNamespaceCodeAndName(FISCAL_OFFICER_ROLE_NAMESPACE, FISCAL_OFFICER_ROLE_NAME);
+        if (fiscalOfficerRole != null && StringUtils.isNotBlank(fiscalOfficerRole.getId())) {
+            return fiscalOfficerRole.getId();
+        }
+        return null;
+    }
+
+    protected List<String> getFiscalOfficerRoleIdAsList() {
+        List<String> roleIdList = new ArrayList<String>();
+        String fiscalOfficerRoleId = getFiscalOfficerRoleId();
+
+        if (StringUtils.isNotBlank(fiscalOfficerRoleId)) {
+            roleIdList.add(fiscalOfficerRoleId);
+        }
+        return roleIdList;
+    }
+
+    @Override
+    public boolean dynamicRoleMembership(String namespaceCode, String roleName) {
+        super.dynamicRoleMembership(namespaceCode, roleName);
+        return true;
+    }
+
+    protected AwardService getAwardService() {
+        return awardService;
+    }
+
+    public void setAwardService(AwardService awardService) {
+        this.awardService = awardService;
+    }
+
+    protected RoleService getRoleService() {
+        return roleService;
+    }
+
+    public void setRoleService(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+}

--- a/coeus-impl/src/main/resources/org/kuali/kra/award/AwardSpringBeans.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/award/AwardSpringBeans.xml
@@ -1182,6 +1182,18 @@
 
     <bean id="awardJavaFunctionKrmsTermService" class="org.kuali.kra.award.service.impl.AwardJavaFunctionKrmsTermServiceImpl"/>
 
+    <bean id="roleService" parent="grlImporter" p:serviceName="kimRoleService" />
+
+    <bean id="fiscalOfficerDerivedRoleTypeService" class="org.kuali.kra.kfs.coa.identity.FiscalOfficerDerivedRoleTypeServiceImpl" >
+        <property name="awardService" ref="awardService" />
+        <property name="roleService" ref="roleService" />
+    </bean>
+
+    <bean id="fiscalOfficerDerivedRoleTypeServiceServiceCallback" parent="kcCoreCallbackService"
+          p:callbackService-ref="fiscalOfficerDerivedRoleTypeService"
+          p:localServiceName="fiscalOfficerDerivedRoleTypeService"
+          p:serviceInterface="org.kuali.rice.kim.framework.role.RoleTypeService"/>
+
     <bean id="awardDtoService" class="org.kuali.kra.external.award.AwardDtoService">
         <property name="businessObjectService" ref="businessObjectService" />
         <property name="parameterService" ref="parameterService"/>


### PR DESCRIPTION
…Fiscal Officers access to KC permissions.

This enhancement creates a new Fiscal Officer Derived Role in the KC-AWARD namespace along with an associated Role Type Service to translate KC-AWARD qualifiers into the required KFS qualifiers (namely accountNumber and chartOfAccountsCode). The new role has no permissions to preserve existing OOB functionality.