### PR TITLE
[RESSUP-1705] use hierarchy name constant and check prime sponsor not null

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/PropDevJavaFunctionKrmsTermServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/krms/PropDevJavaFunctionKrmsTermServiceImpl.java
@@ -163,7 +163,7 @@ public class PropDevJavaFunctionKrmsTermServiceImpl extends KcKrmsJavaFunctionTe
      * 
      * This method checks if the proposal is associated with one of monitored sponsored hierarchies. 
      * see FN_COI_MONITORED_SPONSOR_RULE.
-     * @param monitoredSponsorHirearchies a comma delimited list of sponsored hirearchies.
+     * @param monitoredSponsorHirearchies a comma delimited list of sponsored hierarchies.
      * @return 'true' if true
      */
     @Override
@@ -172,12 +172,13 @@ public class PropDevJavaFunctionKrmsTermServiceImpl extends KcKrmsJavaFunctionTe
         ArrayList<SponsorHierarchy> hierarchies = new ArrayList<>();
         for (String hierarchyName : sponsoredHierarchyArray) {
             Map<String, String> fieldValues = new HashMap<>();
-            fieldValues.put("HIERARCH_NAME", hierarchyName);
+            fieldValues.put(Constants.HIERARCHY_NAME, hierarchyName);
             hierarchies.addAll(this.getBusinessObjectService().findMatching(SponsorHierarchy.class, fieldValues));
         }
         for (SponsorHierarchy sh : hierarchies) {
             if (StringUtils.equalsIgnoreCase(sh.getSponsorCode(), developmentProposal.getSponsor().getSponsorCode())
-                    || StringUtils.equalsIgnoreCase(sh.getSponsorCode(), developmentProposal.getPrimeSponsor().getSponsorCode())) {
+                    || (developmentProposal.getPrimeSponsor() != null && 
+						StringUtils.equalsIgnoreCase(sh.getSponsorCode(), developmentProposal.getPrimeSponsor().getSponsorCode()))) {
                 return TRUE;
             }
         }

--- a/coeus-impl/src/test/java/org/kuali/coeus/propdev/impl/krms/PropDevJavaFunctionKrmsTermServiceImplTest.java
+++ b/coeus-impl/src/test/java/org/kuali/coeus/propdev/impl/krms/PropDevJavaFunctionKrmsTermServiceImplTest.java
@@ -131,7 +131,7 @@ public class PropDevJavaFunctionKrmsTermServiceImplTest {
 	public void test_monitoredSponsorRule() {
 		final String monitoredSponsorHirearchies = "Administering Activity";
 		final Map<String, String> fieldValues = new HashMap<>();
-		fieldValues.put("HIERARCH_NAME", monitoredSponsorHirearchies);
+		fieldValues.put(Constants.HIERARCHY_NAME, monitoredSponsorHirearchies);
 		final ArrayList<SponsorHierarchy> hierarchies = new ArrayList<>();
 		SponsorHierarchy sponsorHierarchy = new SponsorHierarchy();
 		sponsorHierarchy.setSponsorCode("000399");


### PR DESCRIPTION
use the correct field value name for sponsor hierarchy lookup. Also, sometimes prime sponsor is null.